### PR TITLE
[feat] 공통 응답 및 예외 처리 구조 + Swagger 문서화 개선

### DIFF
--- a/src/main/java/com/neuromove/backend/global/api/ApiResponse.java
+++ b/src/main/java/com/neuromove/backend/global/api/ApiResponse.java
@@ -1,0 +1,42 @@
+package com.neuromove.backend.global.api;
+
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(boolean success, String message, T data) {
+        this.success = success;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, message, data);
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, "요청이 성공했습니다.", data);
+    }
+
+    public static ApiResponse<Void> successMessage(String message) {
+        return new ApiResponse<>(true, message, null);
+    }
+
+    public static ApiResponse<Void> error(String message) {
+        return new ApiResponse<>(false, message, null);
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public T getData() {
+        return data;
+    }
+}

--- a/src/main/java/com/neuromove/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/neuromove/backend/global/config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package com.neuromove.backend.global.config;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("NeuroMove Backend API")
+                        .description("NeuroMove 백엔드 API 문서입니다.")
+                        .version("v1.0.0"))
+                .externalDocs(new ExternalDocumentation()
+                        .description("NeuroMove Project Repository"));
+    }
+}

--- a/src/main/java/com/neuromove/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/neuromove/backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.neuromove.backend.global.exception;
+
+import com.neuromove.backend.global.api.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("서버 내부 오류가 발생했습니다."));
+    }
+}

--- a/src/main/java/com/neuromove/backend/test/TestController.java
+++ b/src/main/java/com/neuromove/backend/test/TestController.java
@@ -1,19 +1,24 @@
 package com.neuromove.backend.test;
 
 import com.neuromove.backend.global.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
+@Tag(name = "Test API", description = "테스트용 API입니다.")
 @RestController
 public class TestController {
 
+    @Operation(summary = "정상 응답 테스트", description = "공통 응답 포맷이 정상적으로 동작하는지 확인합니다.")
     @GetMapping("/api/test")
     public ApiResponse<Map<String, String>> test() {
         return ApiResponse.success("테스트 성공", Map.of("name", "neuromove"));
     }
 
+    @Operation(summary = "예외 응답 테스트", description = "공통 예외 처리 응답이 정상적으로 동작하는지 확인합니다.")
     @GetMapping("/api/test/error")
     public ApiResponse<Void> errorTest() {
         throw new IllegalArgumentException("잘못된 요청입니다.");

--- a/src/main/java/com/neuromove/backend/test/TestController.java
+++ b/src/main/java/com/neuromove/backend/test/TestController.java
@@ -13,4 +13,9 @@ public class TestController {
     public ApiResponse<Map<String, String>> test() {
         return ApiResponse.success("테스트 성공", Map.of("name", "neuromove"));
     }
+
+    @GetMapping("/api/test/error")
+    public ApiResponse<Void> errorTest() {
+        throw new IllegalArgumentException("잘못된 요청입니다.");
+    }
 }

--- a/src/main/java/com/neuromove/backend/test/TestController.java
+++ b/src/main/java/com/neuromove/backend/test/TestController.java
@@ -1,0 +1,16 @@
+package com.neuromove.backend.test;
+
+import com.neuromove.backend.global.api.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+public class TestController {
+
+    @GetMapping("/api/test")
+    public ApiResponse<Map<String, String>> test() {
+        return ApiResponse.success("테스트 성공", Map.of("name", "neuromove"));
+    }
+}


### PR DESCRIPTION
### 📌 작업 목적

백엔드 API 개발 시 일관된 응답 구조와 예외 처리 방식을 적용하고,
Swagger 문서를 통해 API 가독성과 이해도를 개선하기 위함입니다.

---

### 🔧 작업 내용

#### 1. 공통 응답 포맷 정의

* `ApiResponse` 클래스 추가
* 모든 API 응답을 다음 구조로 통일

  * success / message / data

#### 2. 공통 예외 처리 (@RestControllerAdvice)

* `GlobalExceptionHandler` 구현
* 주요 예외 처리

  * `IllegalArgumentException` → 400
  * `Exception` → 500
* 모든 에러를 공통 응답 포맷으로 변환

#### 3. Swagger 기본 설정 및 문서화

* `SwaggerConfig` 추가 (OpenAPI 설정)

  * API 제목, 설명, 버전 정의
* 테스트 API에 Swagger 어노테이션 적용

  * `@Tag`, `@Operation` 활용

#### 4. 테스트 API 추가

* `/api/test` : 정상 응답 테스트
* `/api/test/error` : 예외 응답 테스트

---

### 🧪 테스트 내용

* `/api/test`

  * 정상 응답 구조 확인 (200 OK)
* `/api/test/error`

  * 예외 응답 구조 및 상태코드(400) 확인
* Swagger UI에서 API 문서 및 설명 정상 노출 확인

---

### 📦 응답 예시

#### 성공 응답

```json
{
  "success": true,
  "message": "테스트 성공",
  "data": {
    "name": "neuromove"
  }
}
```

#### 실패 응답

```json
{
  "success": false,
  "message": "잘못된 요청입니다.",
  "data": null
}
```

---

### 💡 기대 효과

* API 응답 형식 일관성 확보
* 예외 처리 로직 중앙 집중화로 유지보수 용이
* Swagger 기반 API 문서 가독성 향상
* 이후 로그인, 인증, 도메인 API 개발 시 구조 재사용 가능
