### PR TITLE
[feat] 공통 응답 포맷 및 에외처리 구조 수정

### DIFF
--- a/src/main/java/com/neuromove/backend/global/api/ApiResponse.java
+++ b/src/main/java/com/neuromove/backend/global/api/ApiResponse.java
@@ -1,35 +1,36 @@
 package com.neuromove.backend.global.api;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"success", "code", "message", "data"})
 public class ApiResponse<T> {
 
     private final boolean success;
+    private final String code;
     private final String message;
     private final T data;
 
-    private ApiResponse(boolean success, String message, T data) {
+    private ApiResponse(boolean success, String code, String message, T data) {
         this.success = success;
+        this.code = code;
         this.message = message;
         this.data = data;
     }
 
-    public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(true, message, data);
+    public static <T> ApiResponse<T> success(String code, String message, T data) {
+        return new ApiResponse<>(true, code, message, data);
     }
 
-    public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, "요청이 성공했습니다.", data);
-    }
-
-    public static ApiResponse<Void> successMessage(String message) {
-        return new ApiResponse<>(true, message, null);
-    }
-
-    public static ApiResponse<Void> error(String message) {
-        return new ApiResponse<>(false, message, null);
+    public static ApiResponse<Void> error(String code, String message) {
+        return new ApiResponse<>(false, code, message, null);
     }
 
     public boolean isSuccess() {
         return success;
+    }
+
+    public String getCode() {
+        return code;
     }
 
     public String getMessage() {

--- a/src/main/java/com/neuromove/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/neuromove/backend/global/exception/GlobalExceptionHandler.java
@@ -1,23 +1,29 @@
 package com.neuromove.backend.global.exception;
 
 import com.neuromove.backend.global.api.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("IllegalArgumentException 발생: {}", e.getMessage());
+
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error("INVALID_INPUT", e.getMessage()));
+                .body(ApiResponse.error("INVALID_INPUT", "잘못된 요청입니다."));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unhandled exception 발생", e);
+
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.error("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."));

--- a/src/main/java/com/neuromove/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/neuromove/backend/global/exception/GlobalExceptionHandler.java
@@ -5,9 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -15,15 +13,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(e.getMessage()));
+                .body(ApiResponse.error("INVALID_INPUT", e.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-        log.error("Unhandled server exception occurred", e);
-
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error("서버 내부 오류가 발생했습니다."));
+                .body(ApiResponse.error("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."));
     }
 }

--- a/src/main/java/com/neuromove/backend/test/TestController.java
+++ b/src/main/java/com/neuromove/backend/test/TestController.java
@@ -3,9 +3,9 @@ package com.neuromove.backend.test;
 import com.neuromove.backend.global.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.context.annotation.Profile;
 
 import java.util.Map;
 
@@ -17,7 +17,11 @@ public class TestController {
     @Operation(summary = "정상 응답 테스트", description = "공통 응답 포맷이 정상적으로 동작하는지 확인합니다.")
     @GetMapping("/api/test")
     public ApiResponse<Map<String, String>> test() {
-        return ApiResponse.success("테스트 성공", Map.of("name", "neuromove"));
+        return ApiResponse.success(
+                "TEST_SUCCESS",
+                "테스트 성공",
+                Map.of("name", "neuromove")
+        );
     }
 
     @Operation(summary = "예외 응답 테스트", description = "공통 예외 처리 응답이 정상적으로 동작하는지 확인합니다.")


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->

<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [x] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. 공통 API 응답 포맷(ApiResponse) 구조 추가 및 적용  
2. 기존 응답 형식을 success / code / message / data 형태로 통일  
3. GlobalExceptionHandler를 추가하여 예외 응답을 공통 포맷으로 반환하도록 수정  
4. Swagger 기반 테스트 API 추가 및 응답 형식 검증 
5. local 프로필 기반 DB(MySQL), Redis 환경 설정 및 Docker 연동  
<br>

## 👥 전달사항
1. 앞으로 모든 API는 ApiResponse 형식을 사용해야 합니다.  
2. 예외는 GlobalExceptionHandler를 통해 동일한 형식으로 내려갑니다.  
3. 로컬 실행 시 `local` 프로필 활성화가 필요합니다.  
4. Swagger에서 공통 응답 형식 확인 가능합니다.  

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [ ] 관련 문서가 업데이트됨
- [ ] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="300" height="476" alt="image" src="https://github.com/user-attachments/assets/83528ecd-6068-47b5-b7f6-565d740d1b34" />
<img width="300" height="473" alt="image" src="https://github.com/user-attachments/assets/c81282c6-69e2-49d4-b31e-ad984d486e86" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Standardized responses now include an explicit response code field for all success and error payloads, and success responses carry a corresponding success code.
  * Error responses now return explicit error codes such as INVALID_INPUT and INTERNAL_SERVER_ERROR alongside user-facing messages.

* **Bug Fixes**
  * Exception handlers updated to emit clearer logs and consistent coded error payloads for invalid input and internal errors.

* **Tests**
  * Test endpoint now returns a success code with its existing success message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->