### PR TITLE
[fix] ApiResponse null 방어 로직 추가

### DIFF
--- a/src/main/java/com/neuromove/backend/global/api/ApiResponse.java
+++ b/src/main/java/com/neuromove/backend/global/api/ApiResponse.java
@@ -2,6 +2,8 @@ package com.neuromove.backend.global.api;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.util.Objects;
+
 @JsonPropertyOrder({"success", "code", "message", "data"})
 public class ApiResponse<T> {
 
@@ -12,8 +14,8 @@ public class ApiResponse<T> {
 
     private ApiResponse(boolean success, String code, String message, T data) {
         this.success = success;
-        this.code = code;
-        this.message = message;
+        this.code = Objects.requireNonNull(code, "code must not be null");
+        this.message = Objects.requireNonNull(message, "message must not be null");
         this.data = data;
     }
 


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->

<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
- ApiResponse 생성자에 null 방어 로직 추가
- code, message 필드에 Objects.requireNonNull 적용

<br>

## 👥 전달사항
- 응답 포맷의 안정성을 위해 code, message 필드에 null이 전달되지 않도록 방어 로직을 추가했습니다.

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [ ] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API response reliability by ensuring response codes and messages are always properly validated during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->