### PR TITLE
[feat] EMG/MOTOR 디바이스 등록 및 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/neuromove/backend/domain/device/controller/EmgDeviceController.java
+++ b/src/main/java/com/neuromove/backend/domain/device/controller/EmgDeviceController.java
@@ -1,0 +1,46 @@
+package com.neuromove.backend.domain.device.controller;
+
+import com.neuromove.backend.domain.auth.jwt.CustomUserPrincipal;
+import com.neuromove.backend.domain.device.dto.request.EmgDeviceRegisterRequest;
+import com.neuromove.backend.domain.device.dto.response.EmgDeviceListResponse;
+import com.neuromove.backend.domain.device.dto.response.EmgDeviceRegisterResponse;
+import com.neuromove.backend.domain.device.service.EmgDeviceService;
+import com.neuromove.backend.domain.user.entity.User;
+import com.neuromove.backend.domain.user.repository.UserRepository;
+import com.neuromove.backend.global.api.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/emg-devices")
+@RequiredArgsConstructor
+public class EmgDeviceController {
+
+    private final EmgDeviceService emgDeviceService;
+    private final UserRepository userRepository;
+
+    @PostMapping
+    public ApiResponse<EmgDeviceRegisterResponse> register(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @Valid @RequestBody EmgDeviceRegisterRequest request
+    ) {
+        User user = userRepository.findByUsername(principal.username())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        EmgDeviceRegisterResponse response = emgDeviceService.register(user, request);
+        return ApiResponse.success("EMG_DEVICE_REGISTERED", "EMG 디바이스가 등록되었습니다.", response);
+    }
+
+    @GetMapping
+    public ApiResponse<EmgDeviceListResponse> getMyDevices(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        User user = userRepository.findByUsername(principal.username())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        EmgDeviceListResponse response = emgDeviceService.getMyDevices(user);
+        return ApiResponse.success("EMG_DEVICE_LIST_FETCHED", "EMG 디바이스 목록을 조회했습니다.", response);
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/device/controller/EmgDeviceController.java
+++ b/src/main/java/com/neuromove/backend/domain/device/controller/EmgDeviceController.java
@@ -8,11 +8,13 @@ import com.neuromove.backend.domain.device.service.EmgDeviceService;
 import com.neuromove.backend.domain.user.entity.User;
 import com.neuromove.backend.domain.user.repository.UserRepository;
 import com.neuromove.backend.global.api.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@SecurityRequirement(name = "BearerAuth")
 @RestController
 @RequestMapping("/api/emg-devices")
 @RequiredArgsConstructor

--- a/src/main/java/com/neuromove/backend/domain/device/controller/MotorDeviceController.java
+++ b/src/main/java/com/neuromove/backend/domain/device/controller/MotorDeviceController.java
@@ -1,0 +1,48 @@
+package com.neuromove.backend.domain.device.controller;
+
+import com.neuromove.backend.domain.auth.jwt.CustomUserPrincipal;
+import com.neuromove.backend.domain.device.dto.request.MotorDeviceRegisterRequest;
+import com.neuromove.backend.domain.device.dto.response.MotorDeviceListResponse;
+import com.neuromove.backend.domain.device.dto.response.MotorDeviceRegisterResponse;
+import com.neuromove.backend.domain.device.service.MotorDeviceService;
+import com.neuromove.backend.domain.user.entity.User;
+import com.neuromove.backend.domain.user.repository.UserRepository;
+import com.neuromove.backend.global.api.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@SecurityRequirement(name = "BearerAuth")
+@RestController
+@RequestMapping("/api/motor-devices")
+@RequiredArgsConstructor
+public class MotorDeviceController {
+
+    private final MotorDeviceService motorDeviceService;
+    private final UserRepository userRepository;
+
+    @PostMapping
+    public ApiResponse<MotorDeviceRegisterResponse> register(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @Valid @RequestBody MotorDeviceRegisterRequest request
+    ) {
+        User user = userRepository.findByUsername(principal.username())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        MotorDeviceRegisterResponse response = motorDeviceService.register(user, request);
+        return ApiResponse.success("MOTOR_DEVICE_REGISTERED", "모터 디바이스가 등록되었습니다.", response);
+    }
+
+    @GetMapping
+    public ApiResponse<MotorDeviceListResponse> getMyDevices(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        User user = userRepository.findByUsername(principal.username())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        MotorDeviceListResponse response = motorDeviceService.getMyDevices(user);
+        return ApiResponse.success("MOTOR_DEVICE_LIST_FETCHED", "모터 디바이스 목록을 조회했습니다.", response);
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/device/dto/request/EmgDeviceRegisterRequest.java
+++ b/src/main/java/com/neuromove/backend/domain/device/dto/request/EmgDeviceRegisterRequest.java
@@ -1,0 +1,16 @@
+package com.neuromove.backend.domain.device.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmgDeviceRegisterRequest {
+
+    @NotBlank(message = "EMG 디바이스 ID는 필수입니다.")
+    private String emgDeviceId;
+
+    @NotBlank(message = "디바이스 이름은 필수입니다.")
+    private String name;
+}

--- a/src/main/java/com/neuromove/backend/domain/device/dto/request/MotorDeviceRegisterRequest.java
+++ b/src/main/java/com/neuromove/backend/domain/device/dto/request/MotorDeviceRegisterRequest.java
@@ -1,0 +1,16 @@
+package com.neuromove.backend.domain.device.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MotorDeviceRegisterRequest {
+
+    @NotBlank(message = "모터 디바이스 ID는 필수입니다.")
+    private String motorDeviceId;
+
+    @NotBlank(message = "디바이스 이름은 필수입니다.")
+    private String name;
+}

--- a/src/main/java/com/neuromove/backend/domain/device/dto/response/EmgDeviceListResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/device/dto/response/EmgDeviceListResponse.java
@@ -1,0 +1,13 @@
+package com.neuromove.backend.domain.device.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class EmgDeviceListResponse {
+
+    private List<EmgDeviceResponse> devices;
+}

--- a/src/main/java/com/neuromove/backend/domain/device/dto/response/EmgDeviceRegisterResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/device/dto/response/EmgDeviceRegisterResponse.java
@@ -1,0 +1,28 @@
+package com.neuromove.backend.domain.device.dto.response;
+
+import com.neuromove.backend.domain.device.entity.EmgDevice;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class EmgDeviceRegisterResponse {
+
+    private String emgDeviceId;
+    private String userId;
+    private String name;
+    private boolean isActive;
+    private LocalDateTime createdAt;
+
+    public static EmgDeviceRegisterResponse from(EmgDevice emgDevice) {
+        return EmgDeviceRegisterResponse.builder()
+                .emgDeviceId(emgDevice.getEmgDeviceId())
+                .userId(emgDevice.getUser().getUserId())
+                .name(emgDevice.getName())
+                .isActive(emgDevice.isActive())
+                .createdAt(emgDevice.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/device/dto/response/EmgDeviceResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/device/dto/response/EmgDeviceResponse.java
@@ -1,0 +1,26 @@
+package com.neuromove.backend.domain.device.dto.response;
+
+import com.neuromove.backend.domain.device.entity.EmgDevice;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class EmgDeviceResponse {
+
+    private String emgDeviceId;
+    private String name;
+    private boolean isActive;
+    private LocalDateTime createdAt;
+
+    public static EmgDeviceResponse from(EmgDevice emgDevice) {
+        return EmgDeviceResponse.builder()
+                .emgDeviceId(emgDevice.getEmgDeviceId())
+                .name(emgDevice.getName())
+                .isActive(emgDevice.isActive())
+                .createdAt(emgDevice.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/device/dto/response/MotorDeviceListResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/device/dto/response/MotorDeviceListResponse.java
@@ -1,0 +1,13 @@
+package com.neuromove.backend.domain.device.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MotorDeviceListResponse {
+
+    private List<MotorDeviceResponse> devices;
+}

--- a/src/main/java/com/neuromove/backend/domain/device/dto/response/MotorDeviceRegisterResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/device/dto/response/MotorDeviceRegisterResponse.java
@@ -1,0 +1,30 @@
+package com.neuromove.backend.domain.device.dto.response;
+
+import com.neuromove.backend.domain.device.entity.MotorDevice;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MotorDeviceRegisterResponse {
+
+    private String motorDeviceId;
+    private String userId;
+    private String name;
+    private boolean isActive;
+    private String connectionStatus;
+    private LocalDateTime createdAt;
+
+    public static MotorDeviceRegisterResponse from(MotorDevice motorDevice) {
+        return MotorDeviceRegisterResponse.builder()
+                .motorDeviceId(motorDevice.getMotorDeviceId())
+                .userId(motorDevice.getUser().getUserId())
+                .name(motorDevice.getName())
+                .isActive(motorDevice.isActive())
+                .connectionStatus(motorDevice.getConnectionStatus().name())
+                .createdAt(motorDevice.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/device/dto/response/MotorDeviceResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/device/dto/response/MotorDeviceResponse.java
@@ -1,0 +1,28 @@
+package com.neuromove.backend.domain.device.dto.response;
+
+import com.neuromove.backend.domain.device.entity.MotorDevice;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MotorDeviceResponse {
+
+    private String motorDeviceId;
+    private String name;
+    private boolean isActive;
+    private String connectionStatus;
+    private LocalDateTime createdAt;
+
+    public static MotorDeviceResponse from(MotorDevice motorDevice) {
+        return MotorDeviceResponse.builder()
+                .motorDeviceId(motorDevice.getMotorDeviceId())
+                .name(motorDevice.getName())
+                .isActive(motorDevice.isActive())
+                .connectionStatus(motorDevice.getConnectionStatus().name())
+                .createdAt(motorDevice.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/device/entity/EmgDevice.java
+++ b/src/main/java/com/neuromove/backend/domain/device/entity/EmgDevice.java
@@ -23,7 +23,7 @@ public class EmgDevice {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "name", length = 50)
+    @Column(name = "name", length = 50, nullable = false)
     private String name;
 
     @Column(name = "is_active", nullable = false)

--- a/src/main/java/com/neuromove/backend/domain/device/entity/MotorDevice.java
+++ b/src/main/java/com/neuromove/backend/domain/device/entity/MotorDevice.java
@@ -1,6 +1,7 @@
 package com.neuromove.backend.domain.device.entity;
 
 import com.neuromove.backend.domain.device.entity.enums.ConnectionStatus;
+import com.neuromove.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,7 +20,11 @@ public class MotorDevice {
     @Column(name = "motor_device_id", length = 50)
     private String motorDeviceId;
 
-    @Column(name = "name", length = 50)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "name", length = 50, nullable = false)
     private String name;
 
     @Column(name = "is_active", nullable = false)

--- a/src/main/java/com/neuromove/backend/domain/device/repository/EmgDeviceRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/device/repository/EmgDeviceRepository.java
@@ -1,0 +1,14 @@
+package com.neuromove.backend.domain.device.repository;
+
+import com.neuromove.backend.domain.device.entity.EmgDevice;
+import com.neuromove.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EmgDeviceRepository extends JpaRepository<EmgDevice, String> {
+
+    boolean existsByEmgDeviceId(String emgDeviceId);
+
+    List<EmgDevice> findAllByUserOrderByCreatedAtDesc(User user);
+}

--- a/src/main/java/com/neuromove/backend/domain/device/repository/MotorDeviceRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/device/repository/MotorDeviceRepository.java
@@ -1,0 +1,14 @@
+package com.neuromove.backend.domain.device.repository;
+
+import com.neuromove.backend.domain.device.entity.MotorDevice;
+import com.neuromove.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MotorDeviceRepository extends JpaRepository<MotorDevice, String> {
+
+    boolean existsByMotorDeviceId(String motorDeviceId);
+
+    List<MotorDevice> findAllByUserOrderByCreatedAtDesc(User user);
+}

--- a/src/main/java/com/neuromove/backend/domain/device/service/EmgDeviceService.java
+++ b/src/main/java/com/neuromove/backend/domain/device/service/EmgDeviceService.java
@@ -22,10 +22,6 @@ public class EmgDeviceService {
 
     @Transactional
     public EmgDeviceRegisterResponse register(User user, EmgDeviceRegisterRequest request) {
-        if (emgDeviceRepository.existsByEmgDeviceId(request.getEmgDeviceId())) {
-            throw new IllegalArgumentException("이미 등록된 EMG 디바이스입니다.");
-        }
-
         EmgDevice emgDevice = EmgDevice.builder()
                 .emgDeviceId(request.getEmgDeviceId())
                 .user(user)

--- a/src/main/java/com/neuromove/backend/domain/device/service/EmgDeviceService.java
+++ b/src/main/java/com/neuromove/backend/domain/device/service/EmgDeviceService.java
@@ -1,0 +1,50 @@
+package com.neuromove.backend.domain.device.service;
+
+import com.neuromove.backend.domain.device.dto.request.EmgDeviceRegisterRequest;
+import com.neuromove.backend.domain.device.dto.response.EmgDeviceListResponse;
+import com.neuromove.backend.domain.device.dto.response.EmgDeviceRegisterResponse;
+import com.neuromove.backend.domain.device.dto.response.EmgDeviceResponse;
+import com.neuromove.backend.domain.device.entity.EmgDevice;
+import com.neuromove.backend.domain.device.repository.EmgDeviceRepository;
+import com.neuromove.backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmgDeviceService {
+
+    private final EmgDeviceRepository emgDeviceRepository;
+
+    @Transactional
+    public EmgDeviceRegisterResponse register(User user, EmgDeviceRegisterRequest request) {
+        if (emgDeviceRepository.existsByEmgDeviceId(request.getEmgDeviceId())) {
+            throw new IllegalArgumentException("이미 등록된 EMG 디바이스입니다.");
+        }
+
+        EmgDevice emgDevice = EmgDevice.builder()
+                .emgDeviceId(request.getEmgDeviceId())
+                .user(user)
+                .name(request.getName())
+                .isActive(true)
+                .build();
+
+        EmgDevice savedDevice = emgDeviceRepository.save(emgDevice);
+        return EmgDeviceRegisterResponse.from(savedDevice);
+    }
+
+    public EmgDeviceListResponse getMyDevices(User user) {
+        List<EmgDeviceResponse> devices = emgDeviceRepository.findAllByUserOrderByCreatedAtDesc(user)
+                .stream()
+                .map(EmgDeviceResponse::from)
+                .toList();
+
+        return EmgDeviceListResponse.builder()
+                .devices(devices)
+                .build();
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/device/service/MotorDeviceService.java
+++ b/src/main/java/com/neuromove/backend/domain/device/service/MotorDeviceService.java
@@ -1,0 +1,52 @@
+package com.neuromove.backend.domain.device.service;
+
+import com.neuromove.backend.domain.device.dto.request.MotorDeviceRegisterRequest;
+import com.neuromove.backend.domain.device.dto.response.MotorDeviceListResponse;
+import com.neuromove.backend.domain.device.dto.response.MotorDeviceRegisterResponse;
+import com.neuromove.backend.domain.device.dto.response.MotorDeviceResponse;
+import com.neuromove.backend.domain.device.entity.MotorDevice;
+import com.neuromove.backend.domain.device.entity.enums.ConnectionStatus;
+import com.neuromove.backend.domain.device.repository.MotorDeviceRepository;
+import com.neuromove.backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MotorDeviceService {
+
+    private final MotorDeviceRepository motorDeviceRepository;
+
+    @Transactional
+    public MotorDeviceRegisterResponse register(User user, MotorDeviceRegisterRequest request) {
+        if (motorDeviceRepository.existsByMotorDeviceId(request.getMotorDeviceId())) {
+            throw new IllegalArgumentException("이미 등록된 모터 디바이스입니다.");
+        }
+
+        MotorDevice motorDevice = MotorDevice.builder()
+                .motorDeviceId(request.getMotorDeviceId())
+                .user(user)
+                .name(request.getName())
+                .isActive(true)
+                .connectionStatus(ConnectionStatus.DISCONNECTED)
+                .build();
+
+        MotorDevice savedDevice = motorDeviceRepository.save(motorDevice);
+        return MotorDeviceRegisterResponse.from(savedDevice);
+    }
+
+    public MotorDeviceListResponse getMyDevices(User user) {
+        List<MotorDeviceResponse> devices = motorDeviceRepository.findAllByUserOrderByCreatedAtDesc(user)
+                .stream()
+                .map(MotorDeviceResponse::from)
+                .toList();
+
+        return MotorDeviceListResponse.builder()
+                .devices(devices)
+                .build();
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/device/service/MotorDeviceService.java
+++ b/src/main/java/com/neuromove/backend/domain/device/service/MotorDeviceService.java
@@ -23,10 +23,6 @@ public class MotorDeviceService {
 
     @Transactional
     public MotorDeviceRegisterResponse register(User user, MotorDeviceRegisterRequest request) {
-        if (motorDeviceRepository.existsByMotorDeviceId(request.getMotorDeviceId())) {
-            throw new IllegalArgumentException("이미 등록된 모터 디바이스입니다.");
-        }
-
         MotorDevice motorDevice = MotorDevice.builder()
                 .motorDeviceId(request.getMotorDeviceId())
                 .user(user)

--- a/src/main/java/com/neuromove/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/neuromove/backend/global/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package com.neuromove.backend.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/neuromove/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/neuromove/backend/global/exception/GlobalExceptionHandler.java
@@ -2,11 +2,12 @@ package com.neuromove.backend.global.exception;
 
 import com.neuromove.backend.global.api.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 
 @Slf4j
 @RestControllerAdvice
@@ -41,7 +42,16 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error("INVALID_INPUT", "잘못된 요청입니다."));
+                .body(ApiResponse.error("INVALID_INPUT", e.getMessage()));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        log.warn("DataIntegrityViolationException 발생: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error("DUPLICATE_RESOURCE", "이미 등록된 디바이스입니다."));
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## 🔍 관련 이슈
- close #15

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
- EMG 디바이스 등록 API 구현
- EMG 디바이스 목록 조회 API 구현
- MOTOR 디바이스 등록 API 구현
- MOTOR 디바이스 목록 조회 API 구현
- JWT 인증 기반으로 현재 로그인 사용자와 디바이스 연결
- 디바이스 엔티티 및 레포지토리 구조 정리

<br>

## 👥 전달사항
- 1차 구현에서는 사용자 입력 기반으로 디바이스 등록 흐름을 우선 적용했습니다.
- 현재 등록 API는 다음 범위를 포함합니다.
  - `POST /api/emg-devices`
  - `GET /api/emg-devices`
  - `POST /api/motor-devices`
  - `GET /api/motor-devices`
- 디바이스 등록 시 사용자 정보는 request body로 받지 않고, JWT 인증 정보에서 조회하여 연결하도록 구현했습니다.
- 추후 2차 개선에서 ESP 보드 전원 인가 시 디바이스 정보를 자동 수신하는 방식으로 리팩토링할 예정입니다.
- 이후 개선 예정 범위는 다음과 같습니다.
  - `/api/devices-info` 추가
  - 임시 저장소(Map/Redis) 기반 장치 정보 저장
  - `/api/devices-info/available` 기반 연결 가능한 디바이스 목록 조회
  - 사용자 등록 흐름을 장치 선택 + 이름 설정 방식으로 변경
  - `connectionStatus` 연결 상태 관리 로직 보완

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="400" height="564" alt="image" src="https://github.com/user-attachments/assets/5191c2b2-8fb0-4dc5-97b1-f67ba5281004" />
<img width="400" height="633" alt="image" src="https://github.com/user-attachments/assets/82838868-b56a-4fc9-a0cf-7d00a9c45c20" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Register and view EMG devices (ID + name) in your account
  * Register and view motor devices in your account

* **Bug Fixes**
  * Improved validation: required fields now enforce input and return specific messages
  * Duplicate device registration returns a clear conflict error ("이미 등록된 디바이스입니다.")
  * Error responses surface specific exception messages for clearer feedback
<!-- end of auto-generated comment: release notes by coderabbit.ai -->