### PR TITLE
[feat] Calibration API 구현 (시작/단계변경/종료/프로파일조회)

### DIFF
--- a/src/main/java/com/neuromove/backend/domain/calibration/controller/CalibrationController.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/controller/CalibrationController.java
@@ -1,0 +1,75 @@
+package com.neuromove.backend.domain.calibration.controller;
+
+import com.neuromove.backend.domain.auth.jwt.CustomUserPrincipal;
+import com.neuromove.backend.domain.calibration.dto.request.CalibrationEndRequest;
+import com.neuromove.backend.domain.calibration.dto.request.CalibrationStartRequest;
+import com.neuromove.backend.domain.calibration.dto.request.CalibrationStepUpdateRequest;
+import com.neuromove.backend.domain.calibration.dto.response.*;
+import com.neuromove.backend.domain.calibration.service.CalibrationService;
+import com.neuromove.backend.domain.user.entity.User;
+import com.neuromove.backend.domain.user.repository.UserRepository;
+import com.neuromove.backend.global.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Calibration", description = "Calibration 세션 및 프로파일 관리")
+@SecurityRequirement(name = "BearerAuth")
+@RestController
+@RequestMapping("/api/calibration")
+@RequiredArgsConstructor
+public class CalibrationController {
+
+    private final CalibrationService calibrationService;
+    private final UserRepository userRepository;
+
+    @Operation(summary = "Calibration 시작", description = "선택한 EMG 디바이스 기준으로 Calibration 세션을 시작합니다.")
+    @PostMapping
+    public ApiResponse<CalibrationStartResponse> start(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @Valid @RequestBody CalibrationStartRequest request
+    ) {
+        User user = getUser(principal);
+        CalibrationStartResponse response = calibrationService.start(user, request);
+        return ApiResponse.success("CALIBRATION_STARTED", "Calibration이 시작되었습니다.", response);
+    }
+
+    @Operation(summary = "Calibration 단계 변경", description = "각 단계 완료 후 다음 단계로 진행합니다.")
+    @PatchMapping
+    public ApiResponse<CalibrationStepUpdateResponse> updateStep(
+            @Valid @RequestBody CalibrationStepUpdateRequest request
+    ) {
+        CalibrationStepUpdateResponse response = calibrationService.updateStep(request);
+        return ApiResponse.success("CALIBRATION_STEP_UPDATED", "Calibration 단계가 변경되었습니다.", response);
+    }
+
+@Operation(summary = "Calibration 종료", description = "마지막 단계 완료 후 Calibration을 종료하고 프로파일을 생성합니다.")
+    @PostMapping("/end")
+    public ApiResponse<CalibrationEndResponse> end(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @Valid @RequestBody CalibrationEndRequest request
+    ) {
+        User user = getUser(principal);
+        CalibrationEndResponse response = calibrationService.end(user, request);
+        return ApiResponse.success("CALIBRATION_COMPLETED", "Calibration이 완료되었습니다.", response);
+    }
+
+    @Operation(summary = "Calibration 프로파일 조회", description = "사용자의 활성 Calibration 프로파일을 조회합니다.")
+    @GetMapping("/profile")
+    public ApiResponse<CalibrationProfileResponse> getProfile(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        User user = getUser(principal);
+        CalibrationProfileResponse response = calibrationService.getProfile(user);
+        return ApiResponse.success("CALIBRATION_PROFILE_FETCHED", "Calibration 프로파일을 조회했습니다.", response);
+    }
+
+    private User getUser(CustomUserPrincipal principal) {
+        return userRepository.findByUsername(principal.username())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/controller/CalibrationController.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/controller/CalibrationController.java
@@ -41,9 +41,11 @@ public class CalibrationController {
     @Operation(summary = "Calibration 단계 변경", description = "각 단계 완료 후 다음 단계로 진행합니다.")
     @PatchMapping
     public ApiResponse<CalibrationStepUpdateResponse> updateStep(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @Valid @RequestBody CalibrationStepUpdateRequest request
     ) {
-        CalibrationStepUpdateResponse response = calibrationService.updateStep(request);
+        User user = getUser(principal);
+        CalibrationStepUpdateResponse response = calibrationService.updateStep(user, request);
         return ApiResponse.success("CALIBRATION_STEP_UPDATED", "Calibration 단계가 변경되었습니다.", response);
     }
 

--- a/src/main/java/com/neuromove/backend/domain/calibration/controller/CalibrationController.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/controller/CalibrationController.java
@@ -9,6 +9,8 @@ import com.neuromove.backend.domain.calibration.service.CalibrationService;
 import com.neuromove.backend.domain.user.entity.User;
 import com.neuromove.backend.domain.user.repository.UserRepository;
 import com.neuromove.backend.global.api.ApiResponse;
+import com.neuromove.backend.global.exception.CustomException;
+import com.neuromove.backend.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -72,6 +74,6 @@ public class CalibrationController {
 
     private User getUser(CustomUserPrincipal principal) {
         return userRepository.findByUsername(principal.username())
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/neuromove/backend/domain/calibration/dto/request/CalibrationEndRequest.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/dto/request/CalibrationEndRequest.java
@@ -1,0 +1,13 @@
+package com.neuromove.backend.domain.calibration.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CalibrationEndRequest {
+
+    @NotBlank
+    private String calibrationSessionId;
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/dto/request/CalibrationStartRequest.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/dto/request/CalibrationStartRequest.java
@@ -1,0 +1,13 @@
+package com.neuromove.backend.domain.calibration.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CalibrationStartRequest {
+
+    @NotBlank
+    private String emgDeviceId;
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/dto/request/CalibrationStepUpdateRequest.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/dto/request/CalibrationStepUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.neuromove.backend.domain.calibration.dto.request;
+
+import com.neuromove.backend.domain.calibration.entity.enums.CalibrationStep;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CalibrationStepUpdateRequest {
+
+    @NotBlank
+    private String calibrationSessionId;
+
+    @NotNull
+    private CalibrationStep step;
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/dto/response/CalibrationEndResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/dto/response/CalibrationEndResponse.java
@@ -1,0 +1,28 @@
+package com.neuromove.backend.domain.calibration.dto.response;
+
+import com.neuromove.backend.domain.calibration.entity.CalibrationProfile;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CalibrationEndResponse {
+
+    private String profileId;
+    private String calibrationSessionId;
+    private Float signalQuality;
+    private boolean isActive;
+    private LocalDateTime createdAt;
+
+    public static CalibrationEndResponse from(CalibrationProfile profile) {
+        return CalibrationEndResponse.builder()
+                .profileId(profile.getProfileId())
+                .calibrationSessionId(profile.getCalibrationSessionId())
+                .signalQuality(profile.getSignalQuality())
+                .isActive(profile.isActive())
+                .createdAt(profile.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/dto/response/CalibrationProfileResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/dto/response/CalibrationProfileResponse.java
@@ -1,0 +1,50 @@
+package com.neuromove.backend.domain.calibration.dto.response;
+
+import com.neuromove.backend.domain.calibration.entity.CalibrationProfile;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CalibrationProfileResponse {
+
+    private String profileId;
+    private String userId;
+    private Float ch1Mean;
+    private Float ch1Std;
+    private Float ch2Mean;
+    private Float ch2Std;
+    private Float ch3Mean;
+    private Float ch3Std;
+    private Float activationThreshold;
+    private Float intentThresholdLeft;
+    private Float intentThresholdRight;
+    private Float intentThresholdForward;
+    private Float fatigueBaseline;
+    private Float signalQuality;
+    private boolean isActive;
+    private LocalDateTime updatedAt;
+
+    public static CalibrationProfileResponse from(CalibrationProfile profile) {
+        return CalibrationProfileResponse.builder()
+                .profileId(profile.getProfileId())
+                .userId(profile.getUser().getUserId())
+                .ch1Mean(profile.getCh1Mean())
+                .ch1Std(profile.getCh1Std())
+                .ch2Mean(profile.getCh2Mean())
+                .ch2Std(profile.getCh2Std())
+                .ch3Mean(profile.getCh3Mean())
+                .ch3Std(profile.getCh3Std())
+                .activationThreshold(profile.getActivationThreshold())
+                .intentThresholdLeft(profile.getIntentThresholdLeft())
+                .intentThresholdRight(profile.getIntentThresholdRight())
+                .intentThresholdForward(profile.getIntentThresholdForward())
+                .fatigueBaseline(profile.getFatigueBaseline())
+                .signalQuality(profile.getSignalQuality())
+                .isActive(profile.isActive())
+                .updatedAt(profile.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/dto/response/CalibrationStartResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/dto/response/CalibrationStartResponse.java
@@ -1,0 +1,30 @@
+package com.neuromove.backend.domain.calibration.dto.response;
+
+import com.neuromove.backend.domain.calibration.entity.CalibrationSession;
+import com.neuromove.backend.domain.calibration.entity.enums.CalibrationStatus;
+import com.neuromove.backend.domain.calibration.entity.enums.CalibrationStep;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CalibrationStartResponse {
+
+    private String calibrationSessionId;
+    private String emgDeviceId;
+    private CalibrationStatus status;
+    private CalibrationStep currentStep;
+    private LocalDateTime startedAt;
+
+    public static CalibrationStartResponse from(CalibrationSession session) {
+        return CalibrationStartResponse.builder()
+                .calibrationSessionId(session.getCalibrationSessionId())
+                .emgDeviceId(session.getEmgDevice().getEmgDeviceId())
+                .status(session.getStatus())
+                .currentStep(session.getCurrentStep())
+                .startedAt(session.getStartedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/dto/response/CalibrationStepUpdateResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/dto/response/CalibrationStepUpdateResponse.java
@@ -1,0 +1,27 @@
+package com.neuromove.backend.domain.calibration.dto.response;
+
+import com.neuromove.backend.domain.calibration.entity.CalibrationSession;
+import com.neuromove.backend.domain.calibration.entity.enums.CalibrationStep;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CalibrationStepUpdateResponse {
+
+    private String calibrationSessionId;
+    private CalibrationStep currentStep;
+    private CalibrationStep nextStep;
+    private LocalDateTime updatedAt;
+
+    public static CalibrationStepUpdateResponse from(CalibrationSession session) {
+        return CalibrationStepUpdateResponse.builder()
+                .calibrationSessionId(session.getCalibrationSessionId())
+                .currentStep(session.getCurrentStep())
+                .nextStep(session.getCurrentStep().next())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/entity/CalibrationProfile.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/entity/CalibrationProfile.java
@@ -71,6 +71,10 @@ public class CalibrationProfile {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    public void deactivate() {
+        this.isActive = false;
+    }
+
     @PrePersist
     protected void onCreate() {
         if (this.profileId == null) {

--- a/src/main/java/com/neuromove/backend/domain/calibration/entity/CalibrationSession.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/entity/CalibrationSession.java
@@ -1,0 +1,78 @@
+package com.neuromove.backend.domain.calibration.entity;
+
+import com.neuromove.backend.domain.calibration.entity.enums.CalibrationStatus;
+import com.neuromove.backend.domain.calibration.entity.enums.CalibrationStep;
+import com.neuromove.backend.domain.device.entity.EmgDevice;
+import com.neuromove.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "calibration_sessions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CalibrationSession {
+
+    @Id
+    @Column(name = "calibration_session_id", length = 36)
+    private String calibrationSessionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "emg_device_id", nullable = false)
+    private EmgDevice emgDevice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", columnDefinition = "ENUM('IN_PROGRESS','COMPLETED')", nullable = false)
+    private CalibrationStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "current_step", columnDefinition = "ENUM('REST','LEFT','RIGHT','STOP')", nullable = false)
+    private CalibrationStep currentStep;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "calibration_session_completed_steps",
+            joinColumns = @JoinColumn(name = "calibration_session_id"))
+    @Column(name = "step")
+    @Enumerated(EnumType.STRING)
+    @OrderColumn(name = "step_order")
+    @Builder.Default
+    private List<CalibrationStep> completedSteps = new ArrayList<>();
+
+    @Column(name = "signal_quality")
+    private Float signalQuality;
+
+    @Column(name = "started_at", nullable = false, updatable = false)
+    private LocalDateTime startedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.calibrationSessionId == null) {
+            this.calibrationSessionId = UUID.randomUUID().toString();
+        }
+        this.startedAt = LocalDateTime.now();
+        this.status = CalibrationStatus.IN_PROGRESS;
+        this.currentStep = CalibrationStep.REST;
+    }
+
+    public void proceedToStep(CalibrationStep newStep) {
+        this.completedSteps.add(this.currentStep);
+        this.currentStep = newStep;
+    }
+
+    public void complete(Float signalQuality) {
+        this.completedSteps.add(this.currentStep);
+        this.status = CalibrationStatus.COMPLETED;
+        this.signalQuality = signalQuality;
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/entity/enums/CalibrationStatus.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/entity/enums/CalibrationStatus.java
@@ -1,0 +1,5 @@
+package com.neuromove.backend.domain.calibration.entity.enums;
+
+public enum CalibrationStatus {
+    IN_PROGRESS, COMPLETED
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/entity/enums/CalibrationStep.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/entity/enums/CalibrationStep.java
@@ -1,0 +1,11 @@
+package com.neuromove.backend.domain.calibration.entity.enums;
+
+public enum CalibrationStep {
+    REST, LEFT, RIGHT, STOP;
+
+    public CalibrationStep next() {
+        CalibrationStep[] values = CalibrationStep.values();
+        int nextIdx = this.ordinal() + 1;
+        return nextIdx < values.length ? values[nextIdx] : null;
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/repository/CalibrationProfileRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/repository/CalibrationProfileRepository.java
@@ -1,0 +1,12 @@
+package com.neuromove.backend.domain.calibration.repository;
+
+import com.neuromove.backend.domain.calibration.entity.CalibrationProfile;
+import com.neuromove.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CalibrationProfileRepository extends JpaRepository<CalibrationProfile, String> {
+
+    Optional<CalibrationProfile> findByUserAndIsActiveTrue(User user);
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/repository/CalibrationSessionRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/repository/CalibrationSessionRepository.java
@@ -1,0 +1,7 @@
+package com.neuromove.backend.domain.calibration.repository;
+
+import com.neuromove.backend.domain.calibration.entity.CalibrationSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CalibrationSessionRepository extends JpaRepository<CalibrationSession, String> {
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/service/CalibrationService.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/service/CalibrationService.java
@@ -1,0 +1,117 @@
+package com.neuromove.backend.domain.calibration.service;
+
+import com.neuromove.backend.domain.calibration.dto.request.CalibrationEndRequest;
+import com.neuromove.backend.domain.calibration.dto.request.CalibrationStartRequest;
+import com.neuromove.backend.domain.calibration.dto.request.CalibrationStepUpdateRequest;
+import com.neuromove.backend.domain.calibration.dto.response.*;
+import com.neuromove.backend.domain.calibration.entity.CalibrationProfile;
+import com.neuromove.backend.domain.calibration.entity.CalibrationSession;
+import com.neuromove.backend.domain.calibration.entity.enums.CalibrationStatus;
+import com.neuromove.backend.domain.calibration.entity.enums.CalibrationStep;
+import com.neuromove.backend.domain.calibration.repository.CalibrationProfileRepository;
+import com.neuromove.backend.domain.calibration.repository.CalibrationSessionRepository;
+import com.neuromove.backend.domain.device.entity.EmgDevice;
+import com.neuromove.backend.domain.device.repository.EmgDeviceRepository;
+import com.neuromove.backend.domain.user.entity.User;
+import com.neuromove.backend.global.exception.CustomException;
+import com.neuromove.backend.global.exception.ErrorCode;
+import com.neuromove.backend.infrastructure.ai.calibration.AiCalibrationClient;
+import com.neuromove.backend.infrastructure.ai.calibration.dto.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CalibrationService {
+
+    private final CalibrationSessionRepository calibrationSessionRepository;
+    private final CalibrationProfileRepository calibrationProfileRepository;
+    private final EmgDeviceRepository emgDeviceRepository;
+    private final AiCalibrationClient aiCalibrationClient;
+
+    @Transactional
+    public CalibrationStartResponse start(User user, CalibrationStartRequest request) {
+        EmgDevice emgDevice = emgDeviceRepository.findById(request.getEmgDeviceId())
+                .orElseThrow(() -> new CustomException(ErrorCode.EMG_DEVICE_NOT_FOUND));
+
+        CalibrationSession session = CalibrationSession.builder()
+                .user(user)
+                .emgDevice(emgDevice)
+                .build();
+
+        CalibrationSession saved = calibrationSessionRepository.save(session);
+
+        // TODO: AI 서버 연동 후 주석 해제
+//        aiCalibrationClient.start(AiCalibrationStartRequest.builder()
+//                .calibrationSessionId(saved.getCalibrationSessionId())
+//                .userId(user.getUserId())
+//                .deviceId(emgDevice.getEmgDeviceId())
+//                .initialStep(CalibrationStep.REST.name())
+//                .build());
+
+        return CalibrationStartResponse.from(saved);
+    }
+
+    @Transactional
+    public CalibrationStepUpdateResponse updateStep(CalibrationStepUpdateRequest request) {
+        CalibrationSession session = calibrationSessionRepository.findById(request.getCalibrationSessionId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CALIBRATION_SESSION_NOT_FOUND));
+
+        if (session.getStatus() == CalibrationStatus.COMPLETED) {
+            throw new CustomException(ErrorCode.CALIBRATION_ALREADY_COMPLETED);
+        }
+
+        session.proceedToStep(request.getStep());
+
+        // TODO: AI 서버 연동 후 주석 해제
+//        aiCalibrationClient.updateStep(AiCalibrationStepRequest.builder()
+//                .calibrationSessionId(session.getCalibrationSessionId())
+//                .step(request.getStep().name())
+//                .build());
+
+        return CalibrationStepUpdateResponse.from(session);
+    }
+
+@Transactional
+    public CalibrationEndResponse end(User user, CalibrationEndRequest request) {
+        CalibrationSession session = calibrationSessionRepository.findById(request.getCalibrationSessionId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CALIBRATION_SESSION_NOT_FOUND));
+
+        if (session.getStatus() == CalibrationStatus.COMPLETED) {
+            throw new CustomException(ErrorCode.CALIBRATION_ALREADY_COMPLETED);
+        }
+
+        // TODO: AI 서버 연동 후 아래 더미 데이터 제거하고 주석 해제
+//        AiCalibrationFinishResponse aiResponse = aiCalibrationClient.finish(
+//                AiCalibrationFinishRequest.builder()
+//                        .calibrationSessionId(session.getCalibrationSessionId())
+//                        .build()
+//        );
+//        AiCalibrationFinishResponse.Result result = aiResponse.getData().getResult();
+//        AiCalibrationFinishResponse.Baseline baseline = result.getBaseline();
+//        Map<String, Float> intentThresholds = result.getIntentThresholds();
+//        session.complete(result.getSignalQuality());
+
+        session.complete(null);
+
+        CalibrationProfile profile = CalibrationProfile.builder()
+                .user(user)
+                .calibrationSessionId(session.getCalibrationSessionId())
+                .isActive(true)
+                .build();
+
+        CalibrationProfile saved = calibrationProfileRepository.save(profile);
+        return CalibrationEndResponse.from(saved);
+    }
+
+    public CalibrationProfileResponse getProfile(User user) {
+        CalibrationProfile profile = calibrationProfileRepository.findByUserAndIsActiveTrue(user)
+                .orElseThrow(() -> new CustomException(ErrorCode.CALIBRATION_PROFILE_NOT_FOUND));
+
+        return CalibrationProfileResponse.from(profile);
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/calibration/service/CalibrationService.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/service/CalibrationService.java
@@ -102,6 +102,9 @@ public class CalibrationService {
 
         session.complete(null);
 
+        calibrationProfileRepository.findByUserAndIsActiveTrue(user)
+                .ifPresent(CalibrationProfile::deactivate);
+
         CalibrationProfile profile = CalibrationProfile.builder()
                 .user(user)
                 .calibrationSessionId(session.getCalibrationSessionId())

--- a/src/main/java/com/neuromove/backend/domain/calibration/service/CalibrationService.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/service/CalibrationService.java
@@ -57,9 +57,13 @@ public class CalibrationService {
     }
 
     @Transactional
-    public CalibrationStepUpdateResponse updateStep(CalibrationStepUpdateRequest request) {
+    public CalibrationStepUpdateResponse updateStep(User user, CalibrationStepUpdateRequest request) {
         CalibrationSession session = calibrationSessionRepository.findById(request.getCalibrationSessionId())
                 .orElseThrow(() -> new CustomException(ErrorCode.CALIBRATION_SESSION_NOT_FOUND));
+
+        if (!session.getUser().getUserId().equals(user.getUserId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
 
         if (session.getStatus() == CalibrationStatus.COMPLETED) {
             throw new CustomException(ErrorCode.CALIBRATION_ALREADY_COMPLETED);

--- a/src/main/java/com/neuromove/backend/domain/calibration/service/CalibrationService.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/service/CalibrationService.java
@@ -61,9 +61,7 @@ public class CalibrationService {
         CalibrationSession session = calibrationSessionRepository.findById(request.getCalibrationSessionId())
                 .orElseThrow(() -> new CustomException(ErrorCode.CALIBRATION_SESSION_NOT_FOUND));
 
-        if (!session.getUser().getUserId().equals(user.getUserId())) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
+        validateOwner(user, session);
 
         if (session.getStatus() == CalibrationStatus.COMPLETED) {
             throw new CustomException(ErrorCode.CALIBRATION_ALREADY_COMPLETED);
@@ -84,6 +82,8 @@ public class CalibrationService {
     public CalibrationEndResponse end(User user, CalibrationEndRequest request) {
         CalibrationSession session = calibrationSessionRepository.findById(request.getCalibrationSessionId())
                 .orElseThrow(() -> new CustomException(ErrorCode.CALIBRATION_SESSION_NOT_FOUND));
+
+        validateOwner(user, session);
 
         if (session.getStatus() == CalibrationStatus.COMPLETED) {
             throw new CustomException(ErrorCode.CALIBRATION_ALREADY_COMPLETED);
@@ -110,6 +110,12 @@ public class CalibrationService {
 
         CalibrationProfile saved = calibrationProfileRepository.save(profile);
         return CalibrationEndResponse.from(saved);
+    }
+
+    private void validateOwner(User user, CalibrationSession session) {
+        if (!session.getUser().getUserId().equals(user.getUserId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
     }
 
     public CalibrationProfileResponse getProfile(User user) {

--- a/src/main/java/com/neuromove/backend/domain/device/controller/EmgDeviceController.java
+++ b/src/main/java/com/neuromove/backend/domain/device/controller/EmgDeviceController.java
@@ -8,6 +8,8 @@ import com.neuromove.backend.domain.device.service.EmgDeviceService;
 import com.neuromove.backend.domain.user.entity.User;
 import com.neuromove.backend.domain.user.repository.UserRepository;
 import com.neuromove.backend.global.api.ApiResponse;
+import com.neuromove.backend.global.exception.CustomException;
+import com.neuromove.backend.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +31,7 @@ public class EmgDeviceController {
             @Valid @RequestBody EmgDeviceRegisterRequest request
     ) {
         User user = userRepository.findByUsername(principal.username())
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         EmgDeviceRegisterResponse response = emgDeviceService.register(user, request);
         return ApiResponse.success("EMG_DEVICE_REGISTERED", "EMG 디바이스가 등록되었습니다.", response);
@@ -40,7 +42,7 @@ public class EmgDeviceController {
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
         User user = userRepository.findByUsername(principal.username())
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         EmgDeviceListResponse response = emgDeviceService.getMyDevices(user);
         return ApiResponse.success("EMG_DEVICE_LIST_FETCHED", "EMG 디바이스 목록을 조회했습니다.", response);

--- a/src/main/java/com/neuromove/backend/domain/device/controller/MotorDeviceController.java
+++ b/src/main/java/com/neuromove/backend/domain/device/controller/MotorDeviceController.java
@@ -8,6 +8,8 @@ import com.neuromove.backend.domain.device.service.MotorDeviceService;
 import com.neuromove.backend.domain.user.entity.User;
 import com.neuromove.backend.domain.user.repository.UserRepository;
 import com.neuromove.backend.global.api.ApiResponse;
+import com.neuromove.backend.global.exception.CustomException;
+import com.neuromove.backend.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +31,7 @@ public class MotorDeviceController {
             @Valid @RequestBody MotorDeviceRegisterRequest request
     ) {
         User user = userRepository.findByUsername(principal.username())
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         MotorDeviceRegisterResponse response = motorDeviceService.register(user, request);
         return ApiResponse.success("MOTOR_DEVICE_REGISTERED", "모터 디바이스가 등록되었습니다.", response);
@@ -40,7 +42,7 @@ public class MotorDeviceController {
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
         User user = userRepository.findByUsername(principal.username())
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         MotorDeviceListResponse response = motorDeviceService.getMyDevices(user);
         return ApiResponse.success("MOTOR_DEVICE_LIST_FETCHED", "모터 디바이스 목록을 조회했습니다.", response);

--- a/src/main/java/com/neuromove/backend/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/neuromove/backend/global/config/RestTemplateConfig.java
@@ -2,6 +2,7 @@ package com.neuromove.backend.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -9,6 +10,9 @@ public class RestTemplateConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(10000);
+        factory.setReadTimeout(30000);
+        return new RestTemplate(factory);
     }
 }

--- a/src/main/java/com/neuromove/backend/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/neuromove/backend/global/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.neuromove.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTHENTICATION_FAILED", "아이디 또는 비밀번호가 올바르지 않습니다."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "입력값이 올바르지 않습니다."),
 
+    FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
+
     EMG_DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "EMG_DEVICE_NOT_FOUND", "EMG 디바이스를 찾을 수 없습니다."),
     CALIBRATION_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "CALIBRATION_SESSION_NOT_FOUND", "Calibration 세션을 찾을 수 없습니다."),
     CALIBRATION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "CALIBRATION_ALREADY_COMPLETED", "이미 완료된 Calibration 세션입니다."),

--- a/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
@@ -10,7 +10,12 @@ public enum ErrorCode {
 
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "DUPLICATE_USERNAME", "이미 사용 중인 아이디입니다."),
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTHENTICATION_FAILED", "아이디 또는 비밀번호가 올바르지 않습니다."),
-    INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "입력값이 올바르지 않습니다.");
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "입력값이 올바르지 않습니다."),
+
+    EMG_DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "EMG_DEVICE_NOT_FOUND", "EMG 디바이스를 찾을 수 없습니다."),
+    CALIBRATION_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "CALIBRATION_SESSION_NOT_FOUND", "Calibration 세션을 찾을 수 없습니다."),
+    CALIBRATION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "CALIBRATION_ALREADY_COMPLETED", "이미 완료된 Calibration 세션입니다."),
+    CALIBRATION_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "CALIBRATION_PROFILE_NOT_FOUND", "Calibration 프로파일을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "입력값이 올바르지 않습니다."),
 
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
+    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "USER_NOT_FOUND", "존재하지 않는 사용자입니다."),
 
     EMG_DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "EMG_DEVICE_NOT_FOUND", "EMG 디바이스를 찾을 수 없습니다."),
     CALIBRATION_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "CALIBRATION_SESSION_NOT_FOUND", "Calibration 세션을 찾을 수 없습니다."),

--- a/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/AiCalibrationClient.java
+++ b/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/AiCalibrationClient.java
@@ -1,0 +1,41 @@
+package com.neuromove.backend.infrastructure.ai.calibration;
+
+import com.neuromove.backend.infrastructure.ai.calibration.dto.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class AiCalibrationClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${ai.server.url}")
+    private String aiServerUrl;
+
+    public AiCalibrationStartResponse start(AiCalibrationStartRequest request) {
+        return restTemplate.postForObject(
+                aiServerUrl + "/ai/calibration/start",
+                request,
+                AiCalibrationStartResponse.class
+        );
+    }
+
+    public AiCalibrationStepResponse updateStep(AiCalibrationStepRequest request) {
+        return restTemplate.patchForObject(
+                aiServerUrl + "/ai/calibration/step",
+                request,
+                AiCalibrationStepResponse.class
+        );
+    }
+
+    public AiCalibrationFinishResponse finish(AiCalibrationFinishRequest request) {
+        return restTemplate.postForObject(
+                aiServerUrl + "/ai/calibration/finish",
+                request,
+                AiCalibrationFinishResponse.class
+        );
+    }
+}

--- a/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/dto/AiCalibrationFinishRequest.java
+++ b/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/dto/AiCalibrationFinishRequest.java
@@ -1,0 +1,11 @@
+package com.neuromove.backend.infrastructure.ai.calibration.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AiCalibrationFinishRequest {
+
+    private String calibrationSessionId;
+}

--- a/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/dto/AiCalibrationFinishResponse.java
+++ b/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/dto/AiCalibrationFinishResponse.java
@@ -1,0 +1,46 @@
+package com.neuromove.backend.infrastructure.ai.calibration.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+public class AiCalibrationFinishResponse {
+
+    private boolean success;
+    private String message;
+    private Data data;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Data {
+        private String calibrationSessionId;
+        private String userId;
+        private String deviceId;
+        private Result result;
+        private Long completedAt;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Result {
+        private Baseline baseline;
+        private Float activationThreshold;
+        private Map<String, Float> intentThresholds;
+        private Float fatigueBaseline;
+        private Float signalQuality;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Baseline {
+        private Float ch1Mean;
+        private Float ch1Std;
+        private Float ch2Mean;
+        private Float ch2Std;
+        private Float ch3Mean;
+        private Float ch3Std;
+    }
+}

--- a/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/dto/AiCalibrationStartRequest.java
+++ b/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/dto/AiCalibrationStartRequest.java
@@ -1,0 +1,14 @@
+package com.neuromove.backend.infrastructure.ai.calibration.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AiCalibrationStartRequest {
+
+    private String calibrationSessionId;
+    private String userId;
+    private String deviceId;
+    private String initialStep;
+}

--- a/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/dto/AiCalibrationStartResponse.java
+++ b/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/dto/AiCalibrationStartResponse.java
@@ -1,0 +1,24 @@
+package com.neuromove.backend.infrastructure.ai.calibration.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AiCalibrationStartResponse {
+
+    private boolean success;
+    private String message;
+    private Data data;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Data {
+        private String calibrationSessionId;
+        private String userId;
+        private String deviceId;
+        private String status;
+        private String currentStep;
+        private Long startedAt;
+    }
+}

--- a/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/dto/AiCalibrationStepRequest.java
+++ b/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/dto/AiCalibrationStepRequest.java
@@ -1,0 +1,12 @@
+package com.neuromove.backend.infrastructure.ai.calibration.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AiCalibrationStepRequest {
+
+    private String calibrationSessionId;
+    private String step;
+}

--- a/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/dto/AiCalibrationStepResponse.java
+++ b/src/main/java/com/neuromove/backend/infrastructure/ai/calibration/dto/AiCalibrationStepResponse.java
@@ -1,0 +1,21 @@
+package com.neuromove.backend.infrastructure.ai.calibration.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AiCalibrationStepResponse {
+
+    private boolean success;
+    private String message;
+    private Data data;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Data {
+        private String calibrationSessionId;
+        private String currentStep;
+        private String status;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,3 +15,7 @@ springdoc:
 
 jwt:
   secret: ${JWT_SECRET}
+
+ai:
+  server:
+    url: ${AI_SERVER_URL}


### PR DESCRIPTION
## 🔍 관련 이슈
- close #17 


<br>

## ✅ 작업 분류
- [x] 신규 기능
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
                                                                                                                                                                                                                                                                                                                                           
  **Entity**                                                                                                                                                            
  - CalibrationSession — 캘리브레이션 세션 추적 엔티티 (DB 테이블: calibration_sessions, calibration_session_completed_steps)
  - CalibrationStatus enum — IN_PROGRESS, COMPLETED                                                                                                                 
  - CalibrationStep enum — REST, LEFT, RIGHT, STOP          
                                                                                                                                                                    
  **Repository**                                                                                                                                                        
  - CalibrationSessionRepository                                                                                                                                    
  - CalibrationProfileRepository                                                                                                                                    
                                                            
  **DTO - Request**
  - CalibrationStartRequest — emgDeviceId                                                                                                                           
  - CalibrationStepUpdateRequest — calibrationSessionId, step                                                                                                       
  - CalibrationEndRequest — calibrationSessionId                                                                                                                    
                                                                                                                                                                    
  **DTO - Response**                                            
  - CalibrationStartResponse
  - CalibrationStepUpdateResponse                                                                                                                                   
  - CalibrationEndResponse
  - CalibrationProfileResponse                                                                                                                                      
                                                            
  **Service / Controller**
  - CalibrationService
  - CalibrationController                                                                                                                                           
   
  **AI 클라이언트**                                                                                                                                                     
  - AiCalibrationClient — AI 서버 HTTP 호출                 
  - AiCalibrationStartRequest/Response                                                                                                                              
  - AiCalibrationStepRequest/Response 
  - AiCalibrationFinishRequest/Response                                                                                                                             
                                                                                                                                                                    
  **설정**
  - RestTemplateConfig — RestTemplate 빈 등록                                                                                                                       
                                                                                                                                                                    
  ---
  구현된 API 엔드포인트 (4개)                                                                                                                                       
                                                                                                                                                                    
```
  ┌────────┬──────────────────────────┬──────────────────────────────────┐
  │ Method │           URL            │               설명               │                                                                                          
  ├────────┼──────────────────────────┼──────────────────────────────────┤
  │ POST   │ /api/calibration         │ 캘리브레이션 시작                │
  ├────────┼──────────────────────────┼──────────────────────────────────┤
  │ PATCH  │ /api/calibration         │ 단계 변경 (REST→LEFT→RIGHT→STOP) │
  ├────────┼──────────────────────────┼──────────────────────────────────┤                                                                                          
  │ POST   │ /api/calibration/end     │ 종료 + CalibrationProfile 생성   │
  ├────────┼──────────────────────────┼──────────────────────────────────┤                                                                                          
  │ GET    │ /api/calibration/profile │ 활성 프로파일 조회               │
  └────────┴──────────────────────────┴──────────────────────────────────┘         
```                                                                                 
                                                            
  ---                                                                                                                                                               
  **수정한 파일**                                          
                  
  - ErrorCode — 4개 에러코드 추가 (EMG_DEVICE_NOT_FOUND, CALIBRATION_SESSION_NOT_FOUND, CALIBRATION_ALREADY_COMPLETED, CALIBRATION_PROFILE_NOT_FOUND)
  - application.yaml — AI_SERVER_URL 환경변수 추가                                                                                                                  
  - application-local.yaml — 로컬 개발용 JWT, AI 서버 설정 추가                                                                                                     
                                                                                                                                                                    

<br>

## 👥 전달사항
  1. AI 서버 연동 구조 — /end 호출 시 AI 서버 /ai/calibration/finish를 호출해서 받은 결과(ch1Mean, activationThreshold 등)를 CalibrationProfile에 저장
  2. AI 호출 임시로 주석 처리 — AI 서버 미완성 상태라 AI 호출 코드 주석 처리, TODO 표시해둠. AI 서버 완성 후 주석 해제 필요                                           
  3. 상태 조회 API 제거 — 초기 명세에 있었으나 팀 논의 후 불필요하다고 판단해서 제거함  

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="720" height="421" alt="image" src="https://github.com/user-attachments/assets/253665f6-140d-4ce3-9a8e-b2321a3ef2d5" />
<img width="936" height="571" alt="image" src="https://github.com/user-attachments/assets/5cb246a6-148c-4499-8d13-50cfc65ece6c" />
<img width="749" height="463" alt="image" src="https://github.com/user-attachments/assets/9b1069ae-9562-4b6b-abbf-d454f0cf1525" />
<img width="568" height="553" alt="image" src="https://github.com/user-attachments/assets/65d44d2e-c67d-4932-89d1-85de99f5e6ba" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Complete calibration workflow: start sessions, advance steps, end sessions, and fetch active calibration profiles (with signal quality and metrics).
  * End-to-end AI calibration integration to assist analysis and generate profiles.
* **Improvements**
  * Stronger request validation and clearer error responses for calibration actions.
  * Ending calibration now activates a new profile and deactivates the previous one.
* **Documentation**
  * API endpoints are documented and secured for authenticated use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->