### PR TITLE
[feat] 세션 시작 API 구현

### DIFF
--- a/src/main/java/com/neuromove/backend/domain/session/controller/SessionController.java
+++ b/src/main/java/com/neuromove/backend/domain/session/controller/SessionController.java
@@ -1,0 +1,42 @@
+package com.neuromove.backend.domain.session.controller;
+
+import com.neuromove.backend.domain.auth.jwt.CustomUserPrincipal;
+import com.neuromove.backend.domain.session.dto.request.SessionStartRequest;
+import com.neuromove.backend.domain.session.dto.response.SessionStartResponse;
+import com.neuromove.backend.domain.session.service.SessionService;
+import com.neuromove.backend.domain.user.entity.User;
+import com.neuromove.backend.domain.user.repository.UserRepository;
+import com.neuromove.backend.global.api.ApiResponse;
+import com.neuromove.backend.global.exception.CustomException;
+import com.neuromove.backend.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Session", description = "주행 세션 관리")
+@SecurityRequirement(name = "BearerAuth")
+@RestController
+@RequestMapping("/api/sessions")
+@RequiredArgsConstructor
+public class SessionController {
+
+    private final SessionService sessionService;
+    private final UserRepository userRepository;
+
+    @Operation(summary = "주행 세션 시작", description = "운행 시작 버튼 클릭 시 주행 세션을 시작합니다.")
+    @PostMapping
+    public ApiResponse<SessionStartResponse> start(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @Valid @RequestBody SessionStartRequest request
+    ) {
+        User user = userRepository.findByUsername(principal.username())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        SessionStartResponse response = sessionService.start(user, request);
+        return ApiResponse.success("SESSION_CREATED", "주행 세션이 시작되었습니다.", response);
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/session/dto/request/SessionStartRequest.java
+++ b/src/main/java/com/neuromove/backend/domain/session/dto/request/SessionStartRequest.java
@@ -1,0 +1,19 @@
+package com.neuromove.backend.domain.session.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SessionStartRequest {
+
+    @NotBlank
+    private String profileId;
+
+    @NotBlank
+    private String emgDeviceId;
+
+    @NotBlank
+    private String motorDeviceId;
+}

--- a/src/main/java/com/neuromove/backend/domain/session/dto/response/SessionStartResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/session/dto/response/SessionStartResponse.java
@@ -1,0 +1,33 @@
+package com.neuromove.backend.domain.session.dto.response;
+
+import com.neuromove.backend.domain.session.entity.Session;
+import com.neuromove.backend.domain.session.entity.enums.SessionStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SessionStartResponse {
+
+    private String sessionId;
+    private String userId;
+    private String profileId;
+    private String emgDeviceId;
+    private String motorDeviceId;
+    private SessionStatus status;
+    private LocalDateTime startedAt;
+
+    public static SessionStartResponse from(Session session) {
+        return SessionStartResponse.builder()
+                .sessionId(session.getSessionId())
+                .userId(session.getUser().getUserId())
+                .profileId(session.getCalibrationProfile().getProfileId())
+                .emgDeviceId(session.getEmgDevice().getEmgDeviceId())
+                .motorDeviceId(session.getMotorDevice().getMotorDeviceId())
+                .status(session.getStatus())
+                .startedAt(session.getStartedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/session/repository/SessionRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/session/repository/SessionRepository.java
@@ -1,0 +1,7 @@
+package com.neuromove.backend.domain.session.repository;
+
+import com.neuromove.backend.domain.session.entity.Session;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SessionRepository extends JpaRepository<Session, String> {
+}

--- a/src/main/java/com/neuromove/backend/domain/session/service/SessionService.java
+++ b/src/main/java/com/neuromove/backend/domain/session/service/SessionService.java
@@ -1,0 +1,51 @@
+package com.neuromove.backend.domain.session.service;
+
+import com.neuromove.backend.domain.calibration.entity.CalibrationProfile;
+import com.neuromove.backend.domain.calibration.repository.CalibrationProfileRepository;
+import com.neuromove.backend.domain.device.entity.EmgDevice;
+import com.neuromove.backend.domain.device.entity.MotorDevice;
+import com.neuromove.backend.domain.device.repository.EmgDeviceRepository;
+import com.neuromove.backend.domain.device.repository.MotorDeviceRepository;
+import com.neuromove.backend.domain.session.dto.request.SessionStartRequest;
+import com.neuromove.backend.domain.session.dto.response.SessionStartResponse;
+import com.neuromove.backend.domain.session.entity.Session;
+import com.neuromove.backend.domain.session.repository.SessionRepository;
+import com.neuromove.backend.domain.user.entity.User;
+import com.neuromove.backend.global.exception.CustomException;
+import com.neuromove.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SessionService {
+
+    private final SessionRepository sessionRepository;
+    private final CalibrationProfileRepository calibrationProfileRepository;
+    private final EmgDeviceRepository emgDeviceRepository;
+    private final MotorDeviceRepository motorDeviceRepository;
+
+    @Transactional
+    public SessionStartResponse start(User user, SessionStartRequest request) {
+        CalibrationProfile profile = calibrationProfileRepository.findById(request.getProfileId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CALIBRATION_PROFILE_NOT_FOUND));
+
+        EmgDevice emgDevice = emgDeviceRepository.findById(request.getEmgDeviceId())
+                .orElseThrow(() -> new CustomException(ErrorCode.EMG_DEVICE_NOT_FOUND));
+
+        MotorDevice motorDevice = motorDeviceRepository.findById(request.getMotorDeviceId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MOTOR_DEVICE_NOT_FOUND));
+
+        Session session = Session.builder()
+                .user(user)
+                .calibrationProfile(profile)
+                .emgDevice(emgDevice)
+                .motorDevice(motorDevice)
+                .build();
+
+        Session saved = sessionRepository.save(session);
+        return SessionStartResponse.from(saved);
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/session/service/SessionService.java
+++ b/src/main/java/com/neuromove/backend/domain/session/service/SessionService.java
@@ -31,12 +31,21 @@ public class SessionService {
     public SessionStartResponse start(User user, SessionStartRequest request) {
         CalibrationProfile profile = calibrationProfileRepository.findById(request.getProfileId())
                 .orElseThrow(() -> new CustomException(ErrorCode.CALIBRATION_PROFILE_NOT_FOUND));
+        if (!profile.getUser().getUserId().equals(user.getUserId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
 
         EmgDevice emgDevice = emgDeviceRepository.findById(request.getEmgDeviceId())
                 .orElseThrow(() -> new CustomException(ErrorCode.EMG_DEVICE_NOT_FOUND));
+        if (!emgDevice.getUser().getUserId().equals(user.getUserId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
 
         MotorDevice motorDevice = motorDeviceRepository.findById(request.getMotorDeviceId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MOTOR_DEVICE_NOT_FOUND));
+        if (!motorDevice.getUser().getUserId().equals(user.getUserId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
 
         Session session = Session.builder()
                 .user(user)

--- a/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
@@ -18,7 +18,9 @@ public enum ErrorCode {
     EMG_DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "EMG_DEVICE_NOT_FOUND", "EMG 디바이스를 찾을 수 없습니다."),
     CALIBRATION_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "CALIBRATION_SESSION_NOT_FOUND", "Calibration 세션을 찾을 수 없습니다."),
     CALIBRATION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "CALIBRATION_ALREADY_COMPLETED", "이미 완료된 Calibration 세션입니다."),
-    CALIBRATION_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "CALIBRATION_PROFILE_NOT_FOUND", "Calibration 프로파일을 찾을 수 없습니다.");
+    CALIBRATION_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "CALIBRATION_PROFILE_NOT_FOUND", "Calibration 프로파일을 찾을 수 없습니다."),
+
+    MOTOR_DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "MOTOR_DEVICE_NOT_FOUND", "모터 디바이스를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
## 🔍 관련 이슈
- close #18 


<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
   - `POST /api/sessions` 주행 세션 시작 엔드포인트 구현
   - 세션 시작 시 CalibrationProfile, EmgDevice, MotorDevice 유효성 검증
   - SessionRepository, SessionStartRequest/Response, SessionService, SessionController 신규 추가
   - MOTOR_DEVICE_NOT_FOUND 에러코드 추가

**테스트 사항**
   - [x] 모터 디바이스 등록 후 `GET /api/motor-devices`로 motorDeviceId 확인
   - [x] EMG 디바이스 등록 후 `GET /api/emg-devices`로 emgDeviceId 확인
   - [x] Calibration 완료 후 `GET /api/calibration/profile`로 profileId 확인
   - [x] `POST /api/sessions`에 위 값들 넣어서 세션 생성 확인
   - [x] 존재하지 않는 profileId/emgDeviceId/motorDeviceId 입력 시 404 응답 확인
<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="625" height="400" alt="image" src="https://github.com/user-attachments/assets/49d625d8-648c-4d17-a7f7-f2fc915d1be9" />
<img width="874" height="605" alt="image" src="https://github.com/user-attachments/assets/3c819866-df4e-4c62-9341-d71729f534b3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now initiate driving sessions through a new REST API endpoint with configurable profile and device selections
  * Session startup automatically validates the availability of selected calibration profiles, EMG sensors, and motor devices before initialization
  * Enhanced system with descriptive error messages when required devices or profiles are unavailable during session creation attempts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->