### PR TITLE
[feat] AI 추론 결과 수신 및 Fail-safe 제어 로직 구현

### DIFF
--- a/src/main/java/com/neuromove/backend/domain/command/repository/CommandRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/command/repository/CommandRepository.java
@@ -1,0 +1,7 @@
+package com.neuromove.backend.domain.command.repository;
+
+import com.neuromove.backend.domain.command.entity.Command;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommandRepository extends JpaRepository<Command, String> {
+}

--- a/src/main/java/com/neuromove/backend/domain/fsm/repository/FsmStateRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/fsm/repository/FsmStateRepository.java
@@ -1,0 +1,12 @@
+package com.neuromove.backend.domain.fsm.repository;
+
+import com.neuromove.backend.domain.fsm.entity.FsmState;
+import com.neuromove.backend.domain.session.entity.Session;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FsmStateRepository extends JpaRepository<FsmState, String> {
+
+    Optional<FsmState> findTopBySessionOrderByTransitionedAtDesc(Session session);
+}

--- a/src/main/java/com/neuromove/backend/domain/fsm/service/FsmService.java
+++ b/src/main/java/com/neuromove/backend/domain/fsm/service/FsmService.java
@@ -1,0 +1,40 @@
+package com.neuromove.backend.domain.fsm.service;
+
+import com.neuromove.backend.domain.fsm.entity.FsmState;
+import com.neuromove.backend.domain.fsm.entity.enums.FsmStateType;
+import com.neuromove.backend.domain.fsm.repository.FsmStateRepository;
+import com.neuromove.backend.domain.session.entity.Session;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FsmService {
+
+    private final FsmStateRepository fsmStateRepository;
+
+    public FsmStateType getCurrentState(Session session) {
+        return fsmStateRepository.findTopBySessionOrderByTransitionedAtDesc(session)
+                .map(FsmState::getToState)
+                .orElse(FsmStateType.DRIVING);
+    }
+
+    @Transactional
+    public void transition(Session session, FsmStateType toState, String reason) {
+        FsmStateType fromState = getCurrentState(session);
+
+        if (fromState == toState) {
+            return;
+        }
+
+        FsmState fsmState = FsmState.builder()
+                .session(session)
+                .fromState(fromState)
+                .toState(toState)
+                .reason(reason)
+                .build();
+
+        fsmStateRepository.save(fsmState);
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/intent/controller/IntentController.java
+++ b/src/main/java/com/neuromove/backend/domain/intent/controller/IntentController.java
@@ -1,0 +1,29 @@
+package com.neuromove.backend.domain.intent.controller;
+
+import com.neuromove.backend.domain.intent.dto.request.IntentReceiveRequest;
+import com.neuromove.backend.domain.intent.dto.response.IntentReceiveResponse;
+import com.neuromove.backend.domain.intent.service.IntentService;
+import com.neuromove.backend.global.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "AI Internal", description = "AI 서버 내부 통신 API (X-Internal-Key 인증)")
+@RestController
+@RequestMapping("/api/ai")
+@RequiredArgsConstructor
+public class IntentController {
+
+    private final IntentService intentService;
+
+    @Operation(summary = "AI 추론 결과 수신", description = "AI 서버가 분류한 intent를 수신하여 risk score 계산 후 최종 명령을 결정합니다.")
+    @PostMapping("/intent")
+    public ApiResponse<IntentReceiveResponse> receiveIntent(
+            @Valid @RequestBody IntentReceiveRequest request
+    ) {
+        IntentReceiveResponse response = intentService.receiveIntent(request);
+        return ApiResponse.success("INTENT_RECEIVED", "AI 추론 결과를 수신했습니다.", response);
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/intent/dto/request/IntentReceiveRequest.java
+++ b/src/main/java/com/neuromove/backend/domain/intent/dto/request/IntentReceiveRequest.java
@@ -13,6 +13,9 @@ public class IntentReceiveRequest {
     @NotBlank
     private String sessionId;
 
+    @NotNull
+    private Long sequenceNumber;
+
     @NotBlank
     private String emgDeviceId;
 

--- a/src/main/java/com/neuromove/backend/domain/intent/dto/request/IntentReceiveRequest.java
+++ b/src/main/java/com/neuromove/backend/domain/intent/dto/request/IntentReceiveRequest.java
@@ -1,0 +1,33 @@
+package com.neuromove.backend.domain.intent.dto.request;
+
+import com.neuromove.backend.domain.intent.entity.enums.IntentType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class IntentReceiveRequest {
+
+    @NotBlank
+    private String sessionId;
+
+    @NotBlank
+    private String emgDeviceId;
+
+    @NotNull
+    private Long timestamp;
+
+    @NotNull
+    private IntentType intent;
+
+    @NotNull
+    private Float confidence;
+
+    @NotNull
+    private Float fatigueScore;
+
+    @NotNull
+    private Float signalQuality;
+}

--- a/src/main/java/com/neuromove/backend/domain/intent/dto/response/IntentReceiveResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/intent/dto/response/IntentReceiveResponse.java
@@ -1,0 +1,48 @@
+package com.neuromove.backend.domain.intent.dto.response;
+
+import com.neuromove.backend.domain.command.entity.Command;
+import com.neuromove.backend.domain.command.entity.enums.CommandType;
+import com.neuromove.backend.domain.intent.entity.IntentLog;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class IntentReceiveResponse {
+
+    private String intentId;
+    private String sessionId;
+    private boolean accepted;
+    private float riskScore;
+    private CommandDto command;
+
+    @Getter
+    @Builder
+    public static class CommandDto {
+        private String commandId;
+        private CommandType command;
+        private int speedLevel;
+        private LocalDateTime issuedAt;
+
+        public static CommandDto from(Command command) {
+            return CommandDto.builder()
+                    .commandId(command.getCommandId())
+                    .command(command.getCommand())
+                    .speedLevel(command.getSpeedLevel())
+                    .issuedAt(command.getIssuedAt())
+                    .build();
+        }
+    }
+
+    public static IntentReceiveResponse of(IntentLog intentLog, Command command) {
+        return IntentReceiveResponse.builder()
+                .intentId(intentLog.getIntentId())
+                .sessionId(intentLog.getSession().getSessionId())
+                .accepted(intentLog.getAccepted())
+                .riskScore(intentLog.getRiskScore())
+                .command(CommandDto.from(command))
+                .build();
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/intent/repository/IntentLogRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/intent/repository/IntentLogRepository.java
@@ -1,0 +1,7 @@
+package com.neuromove.backend.domain.intent.repository;
+
+import com.neuromove.backend.domain.intent.entity.IntentLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IntentLogRepository extends JpaRepository<IntentLog, String> {
+}

--- a/src/main/java/com/neuromove/backend/domain/intent/service/IntentService.java
+++ b/src/main/java/com/neuromove/backend/domain/intent/service/IntentService.java
@@ -1,0 +1,110 @@
+package com.neuromove.backend.domain.intent.service;
+
+import com.neuromove.backend.domain.command.entity.Command;
+import com.neuromove.backend.domain.command.entity.enums.CommandType;
+import com.neuromove.backend.domain.command.repository.CommandRepository;
+import com.neuromove.backend.domain.fsm.entity.enums.FsmStateType;
+import com.neuromove.backend.domain.fsm.service.FsmService;
+import com.neuromove.backend.domain.intent.dto.request.IntentReceiveRequest;
+import com.neuromove.backend.domain.intent.dto.response.IntentReceiveResponse;
+import com.neuromove.backend.domain.intent.entity.IntentLog;
+import com.neuromove.backend.domain.intent.repository.IntentLogRepository;
+import com.neuromove.backend.domain.session.entity.Session;
+import com.neuromove.backend.domain.session.repository.SessionRepository;
+import com.neuromove.backend.global.exception.CustomException;
+import com.neuromove.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class IntentService {
+
+    private static final float MAX_DRIVING_MINUTES = 30.0f;
+    private static final float EMERGENCY_STOP_THRESHOLD = 0.7f;
+    private static final float FATIGUE_THRESHOLD = 0.5f;
+
+    private final SessionRepository sessionRepository;
+    private final IntentLogRepository intentLogRepository;
+    private final CommandRepository commandRepository;
+    private final FsmService fsmService;
+
+    @Transactional
+    public IntentReceiveResponse receiveIntent(IntentReceiveRequest request) {
+        Session session = sessionRepository.findById(request.getSessionId())
+                .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
+
+        // 1. durationRatio 계산
+        long elapsedMinutes = Duration.between(session.getStartedAt(), LocalDateTime.now()).toMinutes();
+        float durationRatio = Math.min(elapsedMinutes / MAX_DRIVING_MINUTES, 1.0f);
+
+        // 2. Risk Score 계산 (α·피로도 + β·신호안정성 + γ·지속시간)
+        float fatigueComponent = 0.4f * request.getFatigueScore();
+        float stabilityComponent = 0.4f * (1 - request.getSignalQuality());
+        float durationComponent = 0.2f * durationRatio;
+        float riskScore = fatigueComponent + stabilityComponent + durationComponent;
+
+        // 3. FSM 상태 전이
+        if (riskScore >= EMERGENCY_STOP_THRESHOLD) {
+            fsmService.transition(session, FsmStateType.EMERGENCY_STOP, "RISK_SCORE_EXCEEDED");
+        } else if (riskScore >= FATIGUE_THRESHOLD) {
+            fsmService.transition(session, FsmStateType.FATIGUE_COMPENSATING, "FATIGUE");
+        } else {
+            fsmService.transition(session, FsmStateType.DRIVING, "NORMAL");
+        }
+
+        // 4. speedLevel 및 최종 command 결정
+        boolean accepted = riskScore < EMERGENCY_STOP_THRESHOLD;
+        int speedLevel = calculateSpeedLevel(riskScore);
+        CommandType finalCommand = accepted
+                ? CommandType.valueOf(request.getIntent().name())
+                : CommandType.BLOCKED;
+
+        // 5. max_risk_score 업데이트
+        session.updateMaxRiskScore(riskScore);
+
+        // 6. IntentLog 저장
+        IntentLog intentLog = IntentLog.builder()
+                .session(session)
+                .intent(request.getIntent())
+                .confidence(request.getConfidence())
+                .fatigueScore(request.getFatigueScore())
+                .signalQuality(request.getSignalQuality())
+                .riskScore(riskScore)
+                .fatigueComponent(fatigueComponent)
+                .stabilityComponent(stabilityComponent)
+                .durationComponent(durationComponent)
+                .accepted(accepted)
+                .emgTimestamp(request.getTimestamp())
+                .build();
+
+        IntentLog savedIntent = intentLogRepository.save(intentLog);
+
+        // 7. Command 저장
+        Command command = Command.builder()
+                .session(session)
+                .intentLog(savedIntent)
+                .command(finalCommand)
+                .speedLevel(speedLevel)
+                .riskScore(riskScore)
+                .build();
+
+        Command savedCommand = commandRepository.save(command);
+
+        return IntentReceiveResponse.of(savedIntent, savedCommand);
+    }
+
+    private int calculateSpeedLevel(float riskScore) {
+        if (riskScore < 0.2f) return 5;
+        if (riskScore < 0.3f) return 4;
+        if (riskScore < 0.4f) return 3;
+        if (riskScore < 0.5f) return 2;
+        if (riskScore < 0.7f) return 1;
+        return 0;
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/intent/service/IntentService.java
+++ b/src/main/java/com/neuromove/backend/domain/intent/service/IntentService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Service
@@ -28,6 +29,8 @@ public class IntentService {
     private static final float MAX_DRIVING_MINUTES = 30.0f;
     private static final float EMERGENCY_STOP_THRESHOLD = 0.7f;
     private static final float FATIGUE_THRESHOLD = 0.5f;
+    private static final float CONFIDENCE_THRESHOLD = 0.7f;
+    private static final long STALE_COMMAND_MS = 3000L;
 
     private final SessionRepository sessionRepository;
     private final IntentLogRepository intentLogRepository;
@@ -38,6 +41,20 @@ public class IntentService {
     public IntentReceiveResponse receiveIntent(IntentReceiveRequest request) {
         Session session = sessionRepository.findById(request.getSessionId())
                 .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
+
+        // [Fail-safe 1] sequenceNumber 중복/지연 방지
+        if (session.getLastSequenceNumber() != null
+                && request.getSequenceNumber() <= session.getLastSequenceNumber()) {
+            throw new CustomException(ErrorCode.DUPLICATE_SEQUENCE);
+        }
+        session.updateLastSequenceNumber(request.getSequenceNumber());
+
+        // [Fail-safe 2] 명령 유효시간 처리 (3초 초과 시 BLOCKED)
+        long now = Instant.now().toEpochMilli();
+        boolean stale = (now - request.getTimestamp()) > STALE_COMMAND_MS;
+
+        // [Fail-safe 3] confidence < 0.7 → BLOCKED
+        boolean lowConfidence = request.getConfidence() < CONFIDENCE_THRESHOLD;
 
         // 1. durationRatio 계산
         long elapsedMinutes = Duration.between(session.getStartedAt(), LocalDateTime.now()).toMinutes();
@@ -59,7 +76,7 @@ public class IntentService {
         }
 
         // 4. speedLevel 및 최종 command 결정
-        boolean accepted = riskScore < EMERGENCY_STOP_THRESHOLD;
+        boolean accepted = riskScore < EMERGENCY_STOP_THRESHOLD && !stale && !lowConfidence;
         int speedLevel = calculateSpeedLevel(riskScore);
         CommandType finalCommand = accepted
                 ? CommandType.valueOf(request.getIntent().name())

--- a/src/main/java/com/neuromove/backend/domain/session/entity/Session.java
+++ b/src/main/java/com/neuromove/backend/domain/session/entity/Session.java
@@ -46,6 +46,9 @@ public class Session {
     @Column(name = "max_risk_score")
     private Float maxRiskScore;
 
+    @Column(name = "last_sequence_number")
+    private Long lastSequenceNumber;
+
     @Column(name = "started_at", nullable = false, updatable = false)
     private LocalDateTime startedAt;
 
@@ -54,6 +57,10 @@ public class Session {
 
     @Column(name = "duration_seconds")
     private Integer durationSeconds;
+
+    public void updateLastSequenceNumber(Long sequenceNumber) {
+        this.lastSequenceNumber = sequenceNumber;
+    }
 
     public void updateMaxRiskScore(float riskScore) {
         if (this.maxRiskScore == null || riskScore > this.maxRiskScore) {

--- a/src/main/java/com/neuromove/backend/domain/session/entity/Session.java
+++ b/src/main/java/com/neuromove/backend/domain/session/entity/Session.java
@@ -55,6 +55,12 @@ public class Session {
     @Column(name = "duration_seconds")
     private Integer durationSeconds;
 
+    public void updateMaxRiskScore(float riskScore) {
+        if (this.maxRiskScore == null || riskScore > this.maxRiskScore) {
+            this.maxRiskScore = riskScore;
+        }
+    }
+
     @PrePersist
     protected void onCreate() {
         if (this.sessionId == null) {

--- a/src/main/java/com/neuromove/backend/global/config/SecurityFilterConfig.java
+++ b/src/main/java/com/neuromove/backend/global/config/SecurityFilterConfig.java
@@ -1,6 +1,7 @@
 package com.neuromove.backend.global.config;
 
 import com.neuromove.backend.domain.auth.jwt.JwtAuthenticationFilter;
+import com.neuromove.backend.global.filter.InternalApiKeyFilter;
 import com.neuromove.backend.global.security.JwtAccessDeniedHandler;
 import com.neuromove.backend.global.security.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityFilterConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final InternalApiKeyFilter internalApiKeyFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
@@ -33,13 +35,15 @@ public class SecurityFilterConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/**",
+                                "/api/ai/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(internalApiKeyFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
@@ -20,7 +20,10 @@ public enum ErrorCode {
     CALIBRATION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "CALIBRATION_ALREADY_COMPLETED", "이미 완료된 Calibration 세션입니다."),
     CALIBRATION_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "CALIBRATION_PROFILE_NOT_FOUND", "Calibration 프로파일을 찾을 수 없습니다."),
 
-    MOTOR_DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "MOTOR_DEVICE_NOT_FOUND", "모터 디바이스를 찾을 수 없습니다.");
+    MOTOR_DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "MOTOR_DEVICE_NOT_FOUND", "모터 디바이스를 찾을 수 없습니다."),
+
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", "세션을 찾을 수 없습니다."),
+    INVALID_INTERNAL_KEY(HttpStatus.UNAUTHORIZED, "INVALID_INTERNAL_KEY", "유효하지 않은 Internal Key입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     MOTOR_DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "MOTOR_DEVICE_NOT_FOUND", "모터 디바이스를 찾을 수 없습니다."),
 
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", "세션을 찾을 수 없습니다."),
+    DUPLICATE_SEQUENCE(HttpStatus.BAD_REQUEST, "DUPLICATE_SEQUENCE", "중복되거나 오래된 sequenceNumber입니다."),
     INVALID_INTERNAL_KEY(HttpStatus.UNAUTHORIZED, "INVALID_INTERNAL_KEY", "유효하지 않은 Internal Key입니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/neuromove/backend/global/filter/InternalApiKeyFilter.java
+++ b/src/main/java/com/neuromove/backend/global/filter/InternalApiKeyFilter.java
@@ -1,0 +1,51 @@
+package com.neuromove.backend.global.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.neuromove.backend.global.api.ApiResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class InternalApiKeyFilter extends OncePerRequestFilter {
+
+    private static final String INTERNAL_API_PATH = "/api/ai/";
+    private static final String HEADER_NAME = "X-Internal-Key";
+
+    @Value("${security.api-key}")
+    private String internalApiKey;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (!request.getRequestURI().startsWith(INTERNAL_API_PATH)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String key = request.getHeader(HEADER_NAME);
+        if (!internalApiKey.equals(key)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write(
+                    objectMapper.writeValueAsString(
+                            ApiResponse.error("INVALID_INTERNAL_KEY", "유효하지 않은 Internal Key입니다.")
+                    )
+            );
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
- close #19 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
<p>AI 서버가 분류한 EMG 의도(intent)를 수신하여 <strong>Risk Score 계산 → FSM 상태 전이 → 최종 명령 결정</strong> 까지 처리하는 API와 잘못된 명령이 휠체어에 전달되는 것을 방지하는 Fail-safe 로직을 구현했습니다.</p>
<hr>
<h3>엔드포인트</h3>
<p><code>POST /api/ai/intent X-Internal-Key: {internal-key}</code></p>
<blockquote>
<p>JWT가 아닌 Internal Key 인증 사용 — AI 서버 → 백엔드 내부 통신 전용</p>
</blockquote>
<hr>
<h3>처리 흐름</h3>


```
  AI 서버                                                                                                                                                         
    │  POST /api/ai/intent                                                                                                                                          
    ▼
  InternalApiKeyFilter     ← X-Internal-Key 헤더 검증                                                                                                               
    ▼                                                                                                                                                             
  IntentController
    ▼
  IntentService
    ├── 1. Fail-safe 검증 (sequence / stale / confidence)
    ├── 2. durationRatio 계산                                                                                                                                       
    ├── 3. Risk Score 계산
    ├── 4. accepted 판단     ← (riskScore < 0.7) && !stale && !lowConfidence                                                                                        
    ├── 5. FSM 상태 전이     ← accepted 기준: EMERGENCY_STOP / FATIGUE / DRIVING                                                                                    
    ├── 6. speedLevel 및 최종 command 결정  ← accepted면 1~5, 아니면 0                                                                                              
    ├── 7. session.maxRiskScore 업데이트                                                                                                                            
    ├── 8. IntentLog 저장                                                                                                                                           
    └── 9. Command 저장  
```

<hr>
<h3>Fail-safe 로직</h3>

조건 | 처리 | 이유
-- | -- | --
sequenceNumber 중복/역전 | 400 DUPLICATE_SEQUENCE | 이미 처리한 명령 재실행 방지
timestamp 3초 초과 | accepted=false, BLOCKED, FSM → EMERGENCY_STOP | 오래된 명령이 뒤늦게 실행되는 것 방지
confidence < 0.7 | accepted=false, BLOCKED, FSM → EMERGENCY_STOP | AI 추론 신뢰도 낮은 애매한 명령 방지
모두 통과 | accepted=true, intent 실행 | 정상 처리



<h3>Risk Score 계산 (Kumar et al. 2025 논문 기반)</h3>
<p><code>RiskScore = α·FatigueScore + β·(1 - SignalQuality) + γ·DurationRatio</code></p>

변수 | 가중치 | 설명 | 근거
-- | -- | -- | --
α (Fatigue) | 0.4 | AI가 계산한 피로도 | 오작동 주요 원인
β (Stability) | 0.4 | 신호 불안정도 | 피로도와 동등하게 위험
γ (Duration) | 0.2 | 운행 지속 시간 비율 | 보조 지표

<hr>
<h3>FSM 상태 전이 및 speedLevel</h3>
<p>단순 임계값 기반 정지가 아닌 <strong>3단계 점진적 감속</strong> 구조로 급작스러운 정지로 인한 사고를 방지합니다.</p>

riskScore | FSM 상태 | speedLevel
-- | -- | --
0.0 ~ 0.2 | DRIVING | 5 (최고속)
0.2 ~ 0.3 | DRIVING | 4
0.3 ~ 0.4 | DRIVING | 3
0.4 ~ 0.5 | DRIVING | 2
0.5 ~ 0.7 | FATIGUE_COMPENSATING | 1 (최저속)
0.7 이상 | EMERGENCY_STOP | 0 (차단)


<hr>

<p>모든 FSM 전이 기록은 <code>fsm_states</code> 테이블에 INSERT 방식으로 저장</p>

<!-- notionvc: 7b3d220b-d51c-4c0e-be19-8bb6c9624351 -->
<hr>
<h3>인증 방식</h3>
<p><code>X-Internal-Key 없거나 틀림  →  401 INVALID_INTERNAL_KEY X-Internal-Key 일치         →  통과</code></p>

<p>키 값은 환경변수 <code>security.api-key</code>로 관리 <code>/api/ai/**</code> 경로는 JWT 우회, <code>InternalApiKeyFilter</code>에서 검증</p>


<hr>
<h3>기타 구현 완료</h3>
<ul>
<li>RestTemplate timeout 설정 (connectTimeout: 10s / readTimeout: 30s) — Cascading Failure 방지</li>
<li>FSM 3단계 점진적 감속 (speedLevel 5 → 1 → 0)</li>
</ul>
<!-- notionvc: 6a190983-d3ca-4ec1-b381-676779f787b4 -->

<br>

## 👥 전달사항
-   지금은 타임아웃이 터지면 그냥 500 에러만 남. AI 서버 호출 자체가 주석 처리되어 있어서 아직 연결이 안 된 상태. 수빈이가 웹소켓으로 비상정ㅈ지 추가하면됨
- 앞서 말한 논문의 ESP32 기반 피로도 보정 구조를 참고하여 α=0.4, β=0.4로 설정해놨음 , 추훟에 실제 ESP32 하드웨어 테스트 후 피로도(α) 반응 민감도에 따라 튜닝할 예정
- security.api-key의 my-secret-key는 로컬 테스트용 임시값--> 실제 배포 시 반드시 환경변수로 강력한 키로 교체(AI 서버 측에도 동일한 키값 공유 필요)

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
Swagger UI에서 커스텀 헤더 직접 입력이 안돼서 curl로 테스트
<img width="1495" height="352" alt="image" src="https://github.com/user-attachments/assets/8dac2a6e-9fd5-4e86-a1d0-86b585f88a08" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intent receiving endpoint for AI inference results
  * Implemented FSM state transitions based on session context
  * Added risk scoring evaluation using fatigue, signal quality, and elapsed time factors
  * Enabled command acceptance/blocking based on confidence levels and risk thresholds

* **Chores**
  * Enhanced session tracking with sequence number validation and max risk score monitoring
  * Secured internal API endpoints with key-based authentication
  * Added new error codes for improved error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->