### PR TITLE
[feat] 사용자/세션 조회 API 실제 로직 구현

### DIFF
--- a/src/main/java/com/neuromove/backend/domain/calibration/repository/CalibrationProfileRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/repository/CalibrationProfileRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface CalibrationProfileRepository extends JpaRepository<CalibrationProfile, String> {
 
     Optional<CalibrationProfile> findByUserAndIsActiveTrue(User user);
+
+    Optional<CalibrationProfile> findFirstByUserAndIsActiveTrue(User user);
 }

--- a/src/main/java/com/neuromove/backend/domain/calibration/repository/CalibrationProfileRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/repository/CalibrationProfileRepository.java
@@ -8,7 +8,5 @@ import java.util.Optional;
 
 public interface CalibrationProfileRepository extends JpaRepository<CalibrationProfile, String> {
 
-    Optional<CalibrationProfile> findByUserAndIsActiveTrue(User user);
-
-    Optional<CalibrationProfile> findFirstByUserAndIsActiveTrue(User user);
+    Optional<CalibrationProfile> findFirstByUserAndIsActiveTrueOrderByCreatedAtDesc(User user);
 }

--- a/src/main/java/com/neuromove/backend/domain/calibration/service/CalibrationService.java
+++ b/src/main/java/com/neuromove/backend/domain/calibration/service/CalibrationService.java
@@ -102,7 +102,7 @@ public class CalibrationService {
 
         session.complete(null);
 
-        calibrationProfileRepository.findByUserAndIsActiveTrue(user)
+        calibrationProfileRepository.findFirstByUserAndIsActiveTrueOrderByCreatedAtDesc(user)
                 .ifPresent(CalibrationProfile::deactivate);
 
         CalibrationProfile profile = CalibrationProfile.builder()
@@ -122,7 +122,7 @@ public class CalibrationService {
     }
 
     public CalibrationProfileResponse getProfile(User user) {
-        CalibrationProfile profile = calibrationProfileRepository.findByUserAndIsActiveTrue(user)
+        CalibrationProfile profile = calibrationProfileRepository.findFirstByUserAndIsActiveTrueOrderByCreatedAtDesc(user)
                 .orElseThrow(() -> new CustomException(ErrorCode.CALIBRATION_PROFILE_NOT_FOUND));
 
         return CalibrationProfileResponse.from(profile);

--- a/src/main/java/com/neuromove/backend/domain/device/repository/EmgDeviceRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/device/repository/EmgDeviceRepository.java
@@ -5,10 +5,13 @@ import com.neuromove.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface EmgDeviceRepository extends JpaRepository<EmgDevice, String> {
 
     boolean existsByEmgDeviceId(String emgDeviceId);
 
     List<EmgDevice> findAllByUserOrderByCreatedAtDesc(User user);
+
+    Optional<EmgDevice> findFirstByUserAndIsActiveTrue(User user);
 }

--- a/src/main/java/com/neuromove/backend/domain/device/repository/EmgDeviceRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/device/repository/EmgDeviceRepository.java
@@ -13,5 +13,5 @@ public interface EmgDeviceRepository extends JpaRepository<EmgDevice, String> {
 
     List<EmgDevice> findAllByUserOrderByCreatedAtDesc(User user);
 
-    Optional<EmgDevice> findFirstByUserAndIsActiveTrue(User user);
+    Optional<EmgDevice> findFirstByUserAndIsActiveTrueOrderByCreatedAtDesc(User user);
 }

--- a/src/main/java/com/neuromove/backend/domain/device/repository/MotorDeviceRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/device/repository/MotorDeviceRepository.java
@@ -14,4 +14,5 @@ public interface MotorDeviceRepository extends JpaRepository<MotorDevice, String
 
     List<MotorDevice> findAllByUserOrderByCreatedAtDesc(User user);
 
-    Optional<MotorDevice> findFirstByUserAndIsActiveTrue(User user);}
+    Optional<MotorDevice> findFirstByUserAndIsActiveTrueOrderByCreatedAtDesc(User user);
+}

--- a/src/main/java/com/neuromove/backend/domain/device/repository/MotorDeviceRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/device/repository/MotorDeviceRepository.java
@@ -1,14 +1,17 @@
 package com.neuromove.backend.domain.device.repository;
 
+import com.neuromove.backend.domain.device.entity.EmgDevice;
 import com.neuromove.backend.domain.device.entity.MotorDevice;
 import com.neuromove.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MotorDeviceRepository extends JpaRepository<MotorDevice, String> {
 
     boolean existsByMotorDeviceId(String motorDeviceId);
 
     List<MotorDevice> findAllByUserOrderByCreatedAtDesc(User user);
-}
+
+    Optional<MotorDevice> findFirstByUserAndIsActiveTrue(User user);}

--- a/src/main/java/com/neuromove/backend/domain/fsm/repository/FsmStateRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/fsm/repository/FsmStateRepository.java
@@ -4,9 +4,12 @@ import com.neuromove.backend.domain.fsm.entity.FsmState;
 import com.neuromove.backend.domain.session.entity.Session;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FsmStateRepository extends JpaRepository<FsmState, String> {
 
     Optional<FsmState> findTopBySessionOrderByTransitionedAtDesc(Session session);
+
+    List<FsmState> findAllBySessionOrderByTransitionedAtAsc(Session session);
 }

--- a/src/main/java/com/neuromove/backend/domain/intent/repository/IntentLogRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/intent/repository/IntentLogRepository.java
@@ -1,7 +1,12 @@
 package com.neuromove.backend.domain.intent.repository;
 
 import com.neuromove.backend.domain.intent.entity.IntentLog;
+import com.neuromove.backend.domain.session.entity.Session;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface IntentLogRepository extends JpaRepository<IntentLog, String> {
+
+    List<IntentLog> findAllBySessionOrderByReceivedAtAsc(Session session);
 }

--- a/src/main/java/com/neuromove/backend/domain/session/controller/SessionController.java
+++ b/src/main/java/com/neuromove/backend/domain/session/controller/SessionController.java
@@ -16,12 +16,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import com.neuromove.backend.domain.session.dto.response.FsmStateLogResponse;
-import com.neuromove.backend.domain.session.dto.response.IntentLogResponse;
 import com.neuromove.backend.domain.session.dto.response.SessionDetailResponse;
-import com.neuromove.backend.domain.session.dto.response.SessionSummaryResponse;
-import java.util.List;
-import java.time.LocalDateTime;
 
 @Tag(name = "Session", description = "주행 세션 관리")
 @SecurityRequirement(name = "BearerAuth")
@@ -48,50 +43,12 @@ public class SessionController {
 
     @GetMapping("/{sessionId}/detail")
     public ApiResponse<SessionDetailResponse> getSessionDetail(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable String sessionId
     ) {
-        SessionDetailResponse response = new SessionDetailResponse(
-                new SessionSummaryResponse(
-                        sessionId,
-                        "emg-esp32-A12F",
-                        "motor-esp32-C01",
-                        "ENDED",
-                        LocalDateTime.parse("2026-04-04T14:40:00"),
-                        LocalDateTime.parse("2026-04-04T14:48:20"),
-                        500,
-                        0.78
-                ),
-                List.of(
-                        new FsmStateLogResponse(
-                                "READY",
-                                "DRIVING",
-                                "SESSION_STARTED",
-                                "2026-04-04T14:40:02"
-                        ),
-                        new FsmStateLogResponse(
-                                "DRIVING",
-                                "FATIGUE_COMPENSATING",
-                                "FATIGUE",
-                                "2026-04-04T14:45:10"
-                        )
-                ),
-                List.of(
-                        new IntentLogResponse(
-                                "FORWARD",
-                                0.21,
-                                "2026-04-04T14:41:10"
-                        ),
-                        new IntentLogResponse(
-                                "LEFT",
-                                0.42,
-                                "2026-04-04T14:43:20"
-                        ),
-                        new IntentLogResponse(
-                                "STOP",
-                                0.78,
-                                "2026-04-04T14:47:55"
-                        )
-                )
+        SessionDetailResponse response = sessionService.getSessionDetail(
+                principal.username(),
+                sessionId
         );
 
         return ApiResponse.success("SESSION_DETAIL_FETCHED", "운행 로그 상세를 조회했습니다.", response);

--- a/src/main/java/com/neuromove/backend/domain/session/dto/response/SessionSummaryResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/session/dto/response/SessionSummaryResponse.java
@@ -6,8 +6,8 @@ public record SessionSummaryResponse(
         String emgDeviceId,
         String motorDeviceId,
         String status,
-        LocalDateTime startedAt,
-        LocalDateTime endedAt,
+        String startedAt,
+        String endedAt,
         Integer durationSeconds,
         Double maxRiskScore
 ) {

--- a/src/main/java/com/neuromove/backend/domain/session/repository/SessionRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/session/repository/SessionRepository.java
@@ -1,7 +1,18 @@
 package com.neuromove.backend.domain.session.repository;
 
 import com.neuromove.backend.domain.session.entity.Session;
+import com.neuromove.backend.domain.session.entity.enums.SessionStatus;
+import com.neuromove.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface SessionRepository extends JpaRepository<Session, String> {
+
+    Optional<Session> findFirstByUserAndStatus(User user, SessionStatus status);
+
+    List<Session> findAllByUserOrderByStartedAtDesc(User user);
+
+    Optional<Session> findBySessionIdAndUser(String sessionId, User user);
 }

--- a/src/main/java/com/neuromove/backend/domain/session/service/SessionService.java
+++ b/src/main/java/com/neuromove/backend/domain/session/service/SessionService.java
@@ -6,26 +6,42 @@ import com.neuromove.backend.domain.device.entity.EmgDevice;
 import com.neuromove.backend.domain.device.entity.MotorDevice;
 import com.neuromove.backend.domain.device.repository.EmgDeviceRepository;
 import com.neuromove.backend.domain.device.repository.MotorDeviceRepository;
+import com.neuromove.backend.domain.fsm.entity.FsmState;
+import com.neuromove.backend.domain.fsm.repository.FsmStateRepository;
+import com.neuromove.backend.domain.intent.entity.IntentLog;
+import com.neuromove.backend.domain.intent.repository.IntentLogRepository;
 import com.neuromove.backend.domain.session.dto.request.SessionStartRequest;
+import com.neuromove.backend.domain.session.dto.response.FsmStateLogResponse;
+import com.neuromove.backend.domain.session.dto.response.IntentLogResponse;
+import com.neuromove.backend.domain.session.dto.response.SessionDetailResponse;
 import com.neuromove.backend.domain.session.dto.response.SessionStartResponse;
+import com.neuromove.backend.domain.session.dto.response.SessionSummaryResponse;
 import com.neuromove.backend.domain.session.entity.Session;
 import com.neuromove.backend.domain.session.repository.SessionRepository;
 import com.neuromove.backend.domain.user.entity.User;
+import com.neuromove.backend.domain.user.repository.UserRepository;
 import com.neuromove.backend.global.exception.CustomException;
 import com.neuromove.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class SessionService {
 
+    private final UserRepository userRepository;
     private final SessionRepository sessionRepository;
     private final CalibrationProfileRepository calibrationProfileRepository;
     private final EmgDeviceRepository emgDeviceRepository;
     private final MotorDeviceRepository motorDeviceRepository;
+    private final FsmStateRepository fsmStateRepository;
+    private final IntentLogRepository intentLogRepository;
 
     @Transactional
     public SessionStartResponse start(User user, SessionStartRequest request) {
@@ -56,5 +72,68 @@ public class SessionService {
 
         Session saved = sessionRepository.save(session);
         return SessionStartResponse.from(saved);
+    }
+
+    public SessionDetailResponse getSessionDetail(String username, String sessionId) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Session session = sessionRepository.findBySessionIdAndUser(sessionId, user)
+                .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
+
+        List<FsmStateLogResponse> fsmStates = fsmStateRepository
+                .findAllBySessionOrderByTransitionedAtAsc(session)
+                .stream()
+                .map(this::toFsmStateLogResponse)
+                .toList();
+
+        List<IntentLogResponse> intentLogs = intentLogRepository
+                .findAllBySessionOrderByReceivedAtAsc(session)
+                .stream()
+                .map(this::toIntentLogResponse)
+                .toList();
+
+        return new SessionDetailResponse(
+                toSessionSummaryResponse(session),
+                fsmStates,
+                intentLogs
+        );
+    }
+
+    private SessionSummaryResponse toSessionSummaryResponse(Session session) {
+        return new SessionSummaryResponse(
+                session.getSessionId(),
+                session.getEmgDevice() != null ? session.getEmgDevice().getEmgDeviceId() : null,
+                session.getMotorDevice() != null ? session.getMotorDevice().getMotorDeviceId() : null,
+                session.getStatus().name(),
+                format(session.getStartedAt()),
+                format(session.getEndedAt()),
+                session.getDurationSeconds(),
+                session.getMaxRiskScore() == null ? null : session.getMaxRiskScore().doubleValue()
+        );
+    }
+
+    private FsmStateLogResponse toFsmStateLogResponse(FsmState state) {
+        return new FsmStateLogResponse(
+                state.getFromState() != null ? state.getFromState().name() : null,
+                state.getToState().name(),
+                state.getReason(),
+                format(state.getTransitionedAt())
+        );
+    }
+
+    private IntentLogResponse toIntentLogResponse(IntentLog log) {
+        return new IntentLogResponse(
+                log.getIntent().name(),
+                log.getRiskScore() == null ? null : log.getRiskScore().doubleValue(),
+                format(log.getReceivedAt())
+        );
+    }
+
+    private String format(LocalDateTime time) {
+        if (time == null) {
+            return null;
+        }
+        return time.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
     }
 }

--- a/src/main/java/com/neuromove/backend/domain/session/service/SessionService.java
+++ b/src/main/java/com/neuromove/backend/domain/session/service/SessionService.java
@@ -12,17 +12,15 @@ import com.neuromove.backend.domain.fsm.entity.FsmState;
 import com.neuromove.backend.domain.fsm.repository.FsmStateRepository;
 import com.neuromove.backend.domain.intent.entity.IntentLog;
 import com.neuromove.backend.domain.intent.repository.IntentLogRepository;
+import com.neuromove.backend.domain.session.dto.request.SessionEndRequest;
 import com.neuromove.backend.domain.session.dto.request.SessionStartRequest;
 import com.neuromove.backend.domain.session.dto.response.FsmStateLogResponse;
 import com.neuromove.backend.domain.session.dto.response.IntentLogResponse;
 import com.neuromove.backend.domain.session.dto.response.SessionDetailResponse;
-import com.neuromove.backend.domain.session.dto.response.SessionStartResponse;
-import com.neuromove.backend.domain.session.dto.response.SessionSummaryResponse;
-import com.neuromove.backend.domain.session.dto.request.SessionStartRequest;
-import com.neuromove.backend.domain.session.dto.request.SessionEndRequest;
-import com.neuromove.backend.domain.session.dto.response.SessionStartResponse;
 import com.neuromove.backend.domain.session.dto.response.SessionEndResponse;
+import com.neuromove.backend.domain.session.dto.response.SessionStartResponse;
 import com.neuromove.backend.domain.session.dto.response.SessionStatusResponse;
+import com.neuromove.backend.domain.session.dto.response.SessionSummaryResponse;
 import com.neuromove.backend.domain.session.entity.Session;
 import com.neuromove.backend.domain.session.repository.SessionRepository;
 import com.neuromove.backend.domain.user.entity.User;
@@ -144,7 +142,7 @@ public class SessionService {
         }
         return time.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
     }
-}
+
     public SessionStatusResponse getSessionStatus(String sessionId, String userId) {
         Session session = sessionRepository.findById(sessionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));

--- a/src/main/java/com/neuromove/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/neuromove/backend/domain/user/controller/UserController.java
@@ -1,55 +1,30 @@
 package com.neuromove.backend.domain.user.controller;
 
 import com.neuromove.backend.domain.auth.jwt.CustomUserPrincipal;
-import com.neuromove.backend.domain.user.dto.response.*;
+import com.neuromove.backend.domain.user.dto.response.SessionLogsResponse;
+import com.neuromove.backend.domain.user.dto.response.UserStatusResponse;
+import com.neuromove.backend.domain.user.service.UserService;
 import com.neuromove.backend.global.api.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
-import com.neuromove.backend.domain.user.entity.User;
-import com.neuromove.backend.domain.user.repository.UserRepository;
-import com.neuromove.backend.global.exception.CustomException;
-import com.neuromove.backend.global.exception.ErrorCode;
-import java.util.List;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @SecurityRequirement(name = "BearerAuth")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/users")
 public class UserController {
-    private final UserRepository userRepository;
+
+    private final UserService userService;
 
     @GetMapping("/me")
     public ApiResponse<UserStatusResponse> getMyInfo(
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        User user = userRepository.findByUsername(principal.username())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        UserStatusResponse response = new UserStatusResponse(
-                user.getUserId(),
-                user.getUsername(),
-                user.getName(),
-                new RegisteredEmgDeviceResponse(
-                        "emg-esp32-A12F",
-                        "내 EMG 보드",
-                        true
-                ),
-                new RegisteredMotorDeviceResponse(
-                        "motor-esp32-C01",
-                        "RC카 1번 모터 보드",
-                        true,
-                        "CONNECTED"
-                ),
-                new ActiveCalibrationProfileResponse(
-                        "profile-001",
-                        0.93,
-                        "2026-04-04T14:35:00"
-                ),
-                null
-        );
-
+        UserStatusResponse response = userService.getMyInfo(principal.username());
         return ApiResponse.success("USER_FETCHED", "사용자 상태를 조회했습니다.", response);
     }
 
@@ -57,34 +32,7 @@ public class UserController {
     public ApiResponse<SessionLogsResponse> getMyLogs(
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        User user = userRepository.findByUsername(principal.username())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        SessionLogsResponse response = new SessionLogsResponse(
-                List.of(
-                        new SessionLogItemResponse(
-                                "sess-001",
-                                "emg-esp32-A12F",
-                                "motor-esp32-C01",
-                                "2026-04-03T10:00:00",
-                                "2026-04-03T10:12:10",
-                                730,
-                                0.66,
-                                "ENDED"
-                        ),
-                        new SessionLogItemResponse(
-                                "sess-002",
-                                "emg-esp32-A12F",
-                                "motor-esp32-C01",
-                                "2026-04-04T14:40:00",
-                                "2026-04-04T14:48:20",
-                                500,
-                                0.78,
-                                "ENDED"
-                        )
-                )
-        );
-
+        SessionLogsResponse response = userService.getMyLogs(principal.username());
         return ApiResponse.success("SESSION_LOGS_FETCHED", "운행 로그 목록을 조회했습니다.", response);
     }
 }

--- a/src/main/java/com/neuromove/backend/domain/user/dto/response/ActiveSessionResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/user/dto/response/ActiveSessionResponse.java
@@ -1,0 +1,8 @@
+package com.neuromove.backend.domain.user.dto.response;
+
+public record ActiveSessionResponse(
+        String sessionId,
+        String status,
+        String startedAt
+) {
+}

--- a/src/main/java/com/neuromove/backend/domain/user/dto/response/UserStatusResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/user/dto/response/UserStatusResponse.java
@@ -1,7 +1,5 @@
 package com.neuromove.backend.domain.user.dto.response;
 
-import com.neuromove.backend.domain.session.dto.response.SessionSummaryResponse;
-
 public record UserStatusResponse(
         String userId,
         String username,
@@ -9,6 +7,6 @@ public record UserStatusResponse(
         RegisteredEmgDeviceResponse registeredEmgDevice,
         RegisteredMotorDeviceResponse registeredMotorDevice,
         ActiveCalibrationProfileResponse activeCalibrationProfile,
-        SessionSummaryResponse activeSession
+        ActiveSessionResponse activeSession
 ) {
 }

--- a/src/main/java/com/neuromove/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/neuromove/backend/domain/user/service/UserService.java
@@ -42,13 +42,13 @@ public class UserService {
     public UserStatusResponse getMyInfo(String username) {
         User user = getUserByUsername(username);
 
-        EmgDevice emgDevice = emgDeviceRepository.findFirstByUserAndIsActiveTrue(user)
+        EmgDevice emgDevice = emgDeviceRepository.findFirstByUserAndIsActiveTrueOrderByCreatedAtDesc(user)
                 .orElse(null);
 
-        MotorDevice motorDevice = motorDeviceRepository.findFirstByUserAndIsActiveTrue(user)
+        MotorDevice motorDevice = motorDeviceRepository.findFirstByUserAndIsActiveTrueOrderByCreatedAtDesc(user)
                 .orElse(null);
 
-        CalibrationProfile calibrationProfile = calibrationProfileRepository.findFirstByUserAndIsActiveTrue(user)
+        CalibrationProfile calibrationProfile = calibrationProfileRepository.findFirstByUserAndIsActiveTrueOrderByCreatedAtDesc(user)
                 .orElse(null);
 
         Session activeSession = sessionRepository.findFirstByUserAndStatus(user, SessionStatus.ACTIVE)

--- a/src/main/java/com/neuromove/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/neuromove/backend/domain/user/service/UserService.java
@@ -1,0 +1,152 @@
+package com.neuromove.backend.domain.user.service;
+
+import com.neuromove.backend.domain.calibration.entity.CalibrationProfile;
+import com.neuromove.backend.domain.calibration.repository.CalibrationProfileRepository;
+import com.neuromove.backend.domain.device.entity.EmgDevice;
+import com.neuromove.backend.domain.device.entity.MotorDevice;
+import com.neuromove.backend.domain.device.repository.EmgDeviceRepository;
+import com.neuromove.backend.domain.device.repository.MotorDeviceRepository;
+import com.neuromove.backend.domain.session.entity.Session;
+import com.neuromove.backend.domain.session.entity.enums.SessionStatus;
+import com.neuromove.backend.domain.session.repository.SessionRepository;
+import com.neuromove.backend.domain.user.dto.response.ActiveCalibrationProfileResponse;
+import com.neuromove.backend.domain.user.dto.response.ActiveSessionResponse;
+import com.neuromove.backend.domain.user.dto.response.RegisteredEmgDeviceResponse;
+import com.neuromove.backend.domain.user.dto.response.RegisteredMotorDeviceResponse;
+import com.neuromove.backend.domain.user.dto.response.SessionLogItemResponse;
+import com.neuromove.backend.domain.user.dto.response.SessionLogsResponse;
+import com.neuromove.backend.domain.user.dto.response.UserStatusResponse;
+import com.neuromove.backend.domain.user.entity.User;
+import com.neuromove.backend.domain.user.repository.UserRepository;
+import com.neuromove.backend.global.exception.CustomException;
+import com.neuromove.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final EmgDeviceRepository emgDeviceRepository;
+    private final MotorDeviceRepository motorDeviceRepository;
+    private final CalibrationProfileRepository calibrationProfileRepository;
+    private final SessionRepository sessionRepository;
+
+    public UserStatusResponse getMyInfo(String username) {
+        User user = getUserByUsername(username);
+
+        EmgDevice emgDevice = emgDeviceRepository.findFirstByUserAndIsActiveTrue(user)
+                .orElse(null);
+
+        MotorDevice motorDevice = motorDeviceRepository.findFirstByUserAndIsActiveTrue(user)
+                .orElse(null);
+
+        CalibrationProfile calibrationProfile = calibrationProfileRepository.findFirstByUserAndIsActiveTrue(user)
+                .orElse(null);
+
+        Session activeSession = sessionRepository.findFirstByUserAndStatus(user, SessionStatus.ACTIVE)
+                .orElse(null);
+
+        return new UserStatusResponse(
+                user.getUserId(),
+                user.getUsername(),
+                user.getName(),
+                toRegisteredEmgDeviceResponse(emgDevice),
+                toRegisteredMotorDeviceResponse(motorDevice),
+                toActiveCalibrationProfileResponse(calibrationProfile),
+                toActiveSessionResponse(activeSession)
+        );
+    }
+
+    public SessionLogsResponse getMyLogs(String username) {
+        User user = getUserByUsername(username);
+
+        List<SessionLogItemResponse> logs = sessionRepository.findAllByUserOrderByStartedAtDesc(user)
+                .stream()
+                .map(this::toSessionLogItemResponse)
+                .toList();
+
+        return new SessionLogsResponse(logs);
+    }
+
+    private User getUserByUsername(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private RegisteredEmgDeviceResponse toRegisteredEmgDeviceResponse(EmgDevice emgDevice) {
+        if (emgDevice == null) {
+            return null;
+        }
+
+        return new RegisteredEmgDeviceResponse(
+                emgDevice.getEmgDeviceId(),
+                emgDevice.getName(),
+                emgDevice.isActive()
+        );
+    }
+
+    private RegisteredMotorDeviceResponse toRegisteredMotorDeviceResponse(MotorDevice motorDevice) {
+        if (motorDevice == null) {
+            return null;
+        }
+
+        return new RegisteredMotorDeviceResponse(
+                motorDevice.getMotorDeviceId(),
+                motorDevice.getName(),
+                motorDevice.isActive(),
+                motorDevice.getConnectionStatus().name()
+        );
+    }
+
+    private ActiveCalibrationProfileResponse toActiveCalibrationProfileResponse(CalibrationProfile profile) {
+        if (profile == null) {
+            return null;
+        }
+
+        return new ActiveCalibrationProfileResponse(
+                profile.getProfileId(),
+                profile.getSignalQuality() == null ? null : profile.getSignalQuality().doubleValue(),
+                format(profile.getUpdatedAt())
+        );
+    }
+
+    private ActiveSessionResponse toActiveSessionResponse(Session session) {
+        if (session == null) {
+            return null;
+        }
+
+        return new ActiveSessionResponse(
+                session.getSessionId(),
+                session.getStatus().name(),
+                format(session.getStartedAt())
+        );
+    }
+
+    private SessionLogItemResponse toSessionLogItemResponse(Session session) {
+        return new SessionLogItemResponse(
+                session.getSessionId(),
+                session.getEmgDevice() != null ? session.getEmgDevice().getEmgDeviceId() : null,
+                session.getMotorDevice() != null ? session.getMotorDevice().getMotorDeviceId() : null,
+                format(session.getStartedAt()),
+                format(session.getEndedAt()),
+                session.getDurationSeconds(),
+                session.getMaxRiskScore() == null ? null : session.getMaxRiskScore().doubleValue(),
+                session.getStatus().name()
+        );
+    }
+
+    private String format(LocalDateTime time) {
+        if (time == null) {
+            return null;
+        }
+        return time.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
- close #26

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [x] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
### 1. 세션 상세 조회 API 구현
- `/api/sessions/{sessionId}/detail` 더미 응답 제거
- 세션 소유권 검증 로직 추가
- FSM 상태 로그 조회 로직 구현
- Intent 로그 조회 로직 구현
- SessionService에서 DTO 매핑 처리

### 2. 사용자 상태 조회 API 구현
- `/api/users/me` 실제 조회 로직 구현
- 활성 EMG 디바이스 조회
- 활성 MOTOR 디바이스 조회
- 활성 CalibrationProfile 조회
- 현재 ACTIVE 세션 조회

### 3. 사용자 세션 로그 조회 API 구현
- `/api/users/me/logs` 실제 조회 로직 구현
- 세션 목록 최신순 정렬 조회
- SessionLogItemResponse로 매핑

### 4. Repository 메서드 추가
- SessionRepository
  - findFirstByUserAndStatus
  - findAllByUserOrderByStartedAtDesc
  - findBySessionIdAndUser
- EmgDeviceRepository
- MotorDeviceRepository
- CalibrationProfileRepository

### 5. 구조 개선
- controller → service 구조로 로직 분리
- DTO 시간 타입 LocalDateTime → String 통일
- 더미 응답 제거

<br>

## 👥 전달사항
- Swagger 기준으로 정상 응답 확인 완료
- DB 데이터 기준으로 반환 확인
- 세션/장치/프로파일이 없는 경우 null 처리
- 세션 로그 없는 경우 빈 리스트 반환

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="300" height="726" alt="image" src="https://github.com/user-attachments/assets/356f39ae-aa81-462b-8987-03cdfe3cf9a2" />
<img width="800" height="77" alt="image" src="https://github.com/user-attachments/assets/23571149-55af-4db2-b2a2-70b033176a06" />
<img width="300" height="881" alt="image" src="https://github.com/user-attachments/assets/8dfcbf44-d7f8-4f65-9f22-47eb746a7a4c" />
<img width="300" height="722" alt="image" src="https://github.com/user-attachments/assets/b2e7fcbb-3b6f-41e7-aa87-000f00409ac5" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View detailed session pages with ordered state transitions and intent logs.
  * User profile shows active devices, calibration profile, and current session status.
  * Session history lists all past sessions ordered by start time.
  * Session detail endpoints require an authenticated user and return consistent responses.

* **Refactor**
  * "Active" device/profile now resolves to the most recently created active record.
  * Session timestamps are returned as ISO-local strings for consistent formatting.
  * Active session payload simplified for lighter responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->