### PR TITLE
[feat] 주행 세션 상태 조회 및 종료 API 구현

### DIFF
--- a/src/main/java/com/neuromove/backend/domain/command/repository/CommandRepository.java
+++ b/src/main/java/com/neuromove/backend/domain/command/repository/CommandRepository.java
@@ -1,7 +1,12 @@
 package com.neuromove.backend.domain.command.repository;
 
 import com.neuromove.backend.domain.command.entity.Command;
+import com.neuromove.backend.domain.session.entity.Session;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CommandRepository extends JpaRepository<Command, String> {
+
+    Optional<Command> findTopBySessionOrderByIssuedAtDesc(Session session);
 }

--- a/src/main/java/com/neuromove/backend/domain/session/controller/SessionController.java
+++ b/src/main/java/com/neuromove/backend/domain/session/controller/SessionController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import com.neuromove.backend.domain.session.dto.response.FsmStateLogResponse;
 import com.neuromove.backend.domain.session.dto.response.IntentLogResponse;
 import com.neuromove.backend.domain.session.dto.response.SessionDetailResponse;
+import com.neuromove.backend.domain.session.dto.response.SessionStatusResponse;
 import com.neuromove.backend.domain.session.dto.response.SessionSummaryResponse;
 import java.util.List;
 import java.time.LocalDateTime;
@@ -44,6 +45,16 @@ public class SessionController {
 
         SessionStartResponse response = sessionService.start(user, request);
         return ApiResponse.success("SESSION_CREATED", "주행 세션이 시작되었습니다.", response);
+    }
+
+    @Operation(summary = "세션 상태 조회", description = "웹소켓 연결 전 초기 상태 확인 및 연결 끊김 후 상태 복구 용도로 현재 주행 세션 상태를 1회 조회합니다.")
+    @GetMapping("/{sessionId}/status")
+    public ApiResponse<SessionStatusResponse> getSessionStatus(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable String sessionId
+    ) {
+        SessionStatusResponse response = sessionService.getSessionStatus(sessionId, principal.userId());
+        return ApiResponse.success("SESSION_STATUS_FETCHED", "세션 상태를 조회했습니다.", response);
     }
 
     @GetMapping("/{sessionId}/detail")

--- a/src/main/java/com/neuromove/backend/domain/session/controller/SessionController.java
+++ b/src/main/java/com/neuromove/backend/domain/session/controller/SessionController.java
@@ -2,7 +2,8 @@ package com.neuromove.backend.domain.session.controller;
 
 import com.neuromove.backend.domain.auth.jwt.CustomUserPrincipal;
 import com.neuromove.backend.domain.session.dto.request.SessionStartRequest;
-import com.neuromove.backend.domain.session.dto.response.SessionStartResponse;
+import com.neuromove.backend.domain.session.dto.request.SessionEndRequest;
+import com.neuromove.backend.domain.session.dto.response.*;
 import com.neuromove.backend.domain.session.service.SessionService;
 import com.neuromove.backend.domain.user.entity.User;
 import com.neuromove.backend.domain.user.repository.UserRepository;
@@ -16,13 +17,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import com.neuromove.backend.domain.session.dto.response.FsmStateLogResponse;
-import com.neuromove.backend.domain.session.dto.response.IntentLogResponse;
-import com.neuromove.backend.domain.session.dto.response.SessionDetailResponse;
-import com.neuromove.backend.domain.session.dto.response.SessionStatusResponse;
-import com.neuromove.backend.domain.session.dto.response.SessionSummaryResponse;
-import java.util.List;
+
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Tag(name = "Session", description = "주행 세션 관리")
 @SecurityRequirement(name = "BearerAuth")
@@ -55,6 +52,17 @@ public class SessionController {
     ) {
         SessionStatusResponse response = sessionService.getSessionStatus(sessionId, principal.userId());
         return ApiResponse.success("SESSION_STATUS_FETCHED", "세션 상태를 조회했습니다.", response);
+    }
+
+    @Operation(summary = "주행 세션 종료", description = "운행 종료 시 주행 세션을 종료합니다.")
+    @PostMapping("/{sessionId}/end")
+    public ApiResponse<SessionEndResponse> end(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable String sessionId,
+            @Valid @RequestBody SessionEndRequest request
+    ) {
+        SessionEndResponse response = sessionService.end(sessionId, principal.userId(), request);
+        return ApiResponse.success("SESSION_ENDED", "주행 세션이 종료되었습니다.", response);
     }
 
     @GetMapping("/{sessionId}/detail")

--- a/src/main/java/com/neuromove/backend/domain/session/dto/request/SessionEndRequest.java
+++ b/src/main/java/com/neuromove/backend/domain/session/dto/request/SessionEndRequest.java
@@ -1,0 +1,18 @@
+package com.neuromove.backend.domain.session.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SessionEndRequest {
+
+    @NotBlank(message = "종료 이유는 필수입니다.")
+    @Schema(description = "종료 이유 (USER_REQUEST, SYSTEM_STOP, ERROR, EMERGENCY)", example = "USER_REQUEST")
+    private String reason;
+}

--- a/src/main/java/com/neuromove/backend/domain/session/dto/response/SessionEndResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/session/dto/response/SessionEndResponse.java
@@ -1,0 +1,34 @@
+package com.neuromove.backend.domain.session.dto.response;
+
+import com.neuromove.backend.domain.session.entity.Session;
+import com.neuromove.backend.domain.session.entity.enums.SessionStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SessionEndResponse {
+    private String sessionId;
+    private SessionStatus status;
+    private LocalDateTime startedAt;
+    private LocalDateTime endedAt;
+    private Integer durationSeconds;
+    private Float maxRiskScore;
+
+    public static SessionEndResponse from(Session session) {
+        return SessionEndResponse.builder()
+                .sessionId(session.getSessionId())
+                .status(session.getStatus())
+                .startedAt(session.getStartedAt())
+                .endedAt(session.getEndedAt())
+                .durationSeconds(session.getDurationSeconds())
+                .maxRiskScore(session.getMaxRiskScore())
+                .build();
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/session/dto/response/SessionStatusResponse.java
+++ b/src/main/java/com/neuromove/backend/domain/session/dto/response/SessionStatusResponse.java
@@ -1,0 +1,56 @@
+package com.neuromove.backend.domain.session.dto.response;
+
+import com.neuromove.backend.domain.command.entity.Command;
+import com.neuromove.backend.domain.fsm.entity.FsmState;
+import com.neuromove.backend.domain.session.entity.Session;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SessionStatusResponse {
+
+    private String sessionId;
+    private String status;
+    private String emgDeviceId;
+    private String motorDeviceId;
+    private LocalDateTime startedAt;
+    private LocalDateTime endedAt;
+    private Integer durationSeconds;
+    private Float maxRiskScore;
+    private String latestFsmState;
+    private LatestCommandResponse latestCommand;
+
+    public static SessionStatusResponse of(Session session, FsmState fsmState, Command command) {
+        return SessionStatusResponse.builder()
+                .sessionId(session.getSessionId())
+                .status(session.getStatus().name())
+                .emgDeviceId(session.getEmgDevice().getEmgDeviceId())
+                .motorDeviceId(session.getMotorDevice().getMotorDeviceId())
+                .startedAt(session.getStartedAt())
+                .endedAt(session.getEndedAt())
+                .durationSeconds(session.getDurationSeconds())
+                .maxRiskScore(session.getMaxRiskScore())
+                .latestFsmState(fsmState != null ? fsmState.getToState().name() : null)
+                .latestCommand(command != null ? LatestCommandResponse.from(command) : null)
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class LatestCommandResponse {
+        private String command;
+        private Integer speedLevel;
+        private LocalDateTime issuedAt;
+
+        public static LatestCommandResponse from(Command command) {
+            return LatestCommandResponse.builder()
+                    .command(command.getCommand().name())
+                    .speedLevel(command.getSpeedLevel())
+                    .issuedAt(command.getIssuedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/neuromove/backend/domain/session/entity/Session.java
+++ b/src/main/java/com/neuromove/backend/domain/session/entity/Session.java
@@ -68,6 +68,14 @@ public class Session {
         }
     }
 
+    public void end() {
+        this.status = SessionStatus.ENDED;
+        this.endedAt = LocalDateTime.now();
+        if (this.startedAt != null) {
+            this.durationSeconds = (int) java.time.Duration.between(this.startedAt, this.endedAt).getSeconds();
+        }
+    }
+
     @PrePersist
     protected void onCreate() {
         if (this.sessionId == null) {

--- a/src/main/java/com/neuromove/backend/domain/session/service/SessionService.java
+++ b/src/main/java/com/neuromove/backend/domain/session/service/SessionService.java
@@ -2,12 +2,17 @@ package com.neuromove.backend.domain.session.service;
 
 import com.neuromove.backend.domain.calibration.entity.CalibrationProfile;
 import com.neuromove.backend.domain.calibration.repository.CalibrationProfileRepository;
+import com.neuromove.backend.domain.command.entity.Command;
+import com.neuromove.backend.domain.command.repository.CommandRepository;
 import com.neuromove.backend.domain.device.entity.EmgDevice;
 import com.neuromove.backend.domain.device.entity.MotorDevice;
 import com.neuromove.backend.domain.device.repository.EmgDeviceRepository;
 import com.neuromove.backend.domain.device.repository.MotorDeviceRepository;
+import com.neuromove.backend.domain.fsm.entity.FsmState;
+import com.neuromove.backend.domain.fsm.repository.FsmStateRepository;
 import com.neuromove.backend.domain.session.dto.request.SessionStartRequest;
 import com.neuromove.backend.domain.session.dto.response.SessionStartResponse;
+import com.neuromove.backend.domain.session.dto.response.SessionStatusResponse;
 import com.neuromove.backend.domain.session.entity.Session;
 import com.neuromove.backend.domain.session.repository.SessionRepository;
 import com.neuromove.backend.domain.user.entity.User;
@@ -26,6 +31,8 @@ public class SessionService {
     private final CalibrationProfileRepository calibrationProfileRepository;
     private final EmgDeviceRepository emgDeviceRepository;
     private final MotorDeviceRepository motorDeviceRepository;
+    private final FsmStateRepository fsmStateRepository;
+    private final CommandRepository commandRepository;
 
     @Transactional
     public SessionStartResponse start(User user, SessionStartRequest request) {
@@ -56,5 +63,21 @@ public class SessionService {
 
         Session saved = sessionRepository.save(session);
         return SessionStartResponse.from(saved);
+    }
+
+    public SessionStatusResponse getSessionStatus(String sessionId, String userId) {
+        Session session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
+
+        if (!session.getUser().getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        FsmState latestFsmState = fsmStateRepository.findTopBySessionOrderByTransitionedAtDesc(session)
+                .orElse(null);
+        Command latestCommand = commandRepository.findTopBySessionOrderByIssuedAtDesc(session)
+                .orElse(null);
+
+        return SessionStatusResponse.of(session, latestFsmState, latestCommand);
     }
 }

--- a/src/main/java/com/neuromove/backend/domain/session/service/SessionService.java
+++ b/src/main/java/com/neuromove/backend/domain/session/service/SessionService.java
@@ -11,7 +11,9 @@ import com.neuromove.backend.domain.device.repository.MotorDeviceRepository;
 import com.neuromove.backend.domain.fsm.entity.FsmState;
 import com.neuromove.backend.domain.fsm.repository.FsmStateRepository;
 import com.neuromove.backend.domain.session.dto.request.SessionStartRequest;
+import com.neuromove.backend.domain.session.dto.request.SessionEndRequest;
 import com.neuromove.backend.domain.session.dto.response.SessionStartResponse;
+import com.neuromove.backend.domain.session.dto.response.SessionEndResponse;
 import com.neuromove.backend.domain.session.dto.response.SessionStatusResponse;
 import com.neuromove.backend.domain.session.entity.Session;
 import com.neuromove.backend.domain.session.repository.SessionRepository;
@@ -79,5 +81,22 @@ public class SessionService {
                 .orElse(null);
 
         return SessionStatusResponse.of(session, latestFsmState, latestCommand);
+    }
+
+    @Transactional
+    public SessionEndResponse end(String sessionId, String userId, SessionEndRequest request) {
+        Session session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
+
+        if (!session.getUser().getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        if (session.getStatus() == com.neuromove.backend.domain.session.entity.enums.SessionStatus.ENDED) {
+            return SessionEndResponse.from(session);
+        }
+
+        session.end();
+        return SessionEndResponse.from(session);
     }
 }


### PR DESCRIPTION
## 🔍 관련 이슈

- close #20 


<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## 작업 내용
1. 운행 중인 주행 세션의 실시간 상태를 확인하고, 운행 종료 시 세션을 안전하게 닫고 결과 데이터를 집계하는 기능을 구현했습니다. 모든 API는 JWT 기반의 인증을 거치며,
본인 소유의 세션에 대해서만 접근이 가능하도록 보안 로직을 강화했습니다.
2. 주요 변경 사항 

 **Domain Logic & Entity (Session.java)**

- 세션 종료 로직 구현: end() 메서드를 엔티티 내부에 구현하여 비즈니스 로직의 응집도를 높였습니다.
    - 상태(status)를 ACTIVE -> ENDED로 변경합니다.
    - 종료 시각을 기록합니다.
    - 시작 시각과 종료 시각의 차이를 계산하여 총 주행 시간(durationSeconds)을 업데이트합니다.

**SessionService.java**

- getSessionStatus:
    - 세션 정보뿐만 아니라, 해당 세션에서 발생한 최신 FSM 상태와 최신 제어 명령을 함께 조회하여 클라이언트가 현재 차량의 물리적/논리적 상태를 한
    번에 파악할 수 있게 합니다.
- end:
    - 세션 존재 여부 및 사용자 권한(User ID 일치 여부)을 검증합니다.
    - 이미 종료된 세션에 대한 중복 종료 요청 시, 에러 대신 현재 세션 상태를 반환하도록 예외 처리를 하여 멱등성을 보장했습니다.

**SessionController**

- GET /api/sessions/{sessionId}/status: 웹소켓 연결 전 초기 상태 동기화 및 재연결 시 상태 복구용 API입니다.
- POST /api/sessions/{sessionId}/end: 운행 종료 버튼 클릭 시 호출되는 API로, 주행 결과 요약 데이터를 반환합니다.

**DTOs**

- SessionEndRequest: 종료 이유를 전달받습니다. (예: USER_REQUEST, EMERGENCY 등)
- SessionEndResponse: 종료된 세션의 요약 정보(주행 시간, 최대 위험 점수 등)를 포함합니다.
- SessionStatusResponse: 세션 기본 정보 + 최신 FSM 로그 + 최신 명령 정보를 통합한 구조입니다.

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="886" height="575" alt="image" src="https://github.com/user-attachments/assets/73c7ce38-e1cb-40ca-befb-e562b942a3a4" />
<img width="890" height="644" alt="image" src="https://github.com/user-attachments/assets/dddc86d0-ac61-44e6-a5d0-fffaa8813d52" />
