### PR TITLE
[fix] Redis prod 포트를 Docker 내부 포트에 맞게 수정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,7 +21,7 @@ spring:
   data:
     redis:
       host: redis
-      port: 6380
+      port: 6379
 
 security:
   api-key: ${SECURITY_API_KEY:CHANGE_ME_IN_PRODUCTION}


### PR DESCRIPTION
### 코드리뷰 반영
- Docker Compose 환경에서는 backend가 Redis 컨테이너에 내부 네트워크로 접근
- host는 redis, port는 내부 포트인 6379를 사용
- 6380:6379 포트 매핑은 호스트 외부 접근용이므로 application-prod.yml은 6379로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Redis connection configuration in the production environment to ensure reliable database connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->