### PR TITLE
[fix] 디바이스 등록 성공 후 Redis latest key 삭제하도록 수정

### DIFF
--- a/src/main/java/com/neuromove/backend/domain/device/service/DeviceInfoService.java
+++ b/src/main/java/com/neuromove/backend/domain/device/service/DeviceInfoService.java
@@ -7,11 +7,13 @@ import com.neuromove.backend.domain.device.dto.response.MotorDeviceInfoResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.Map;
 
 @Slf4j
@@ -25,6 +27,27 @@ public class DeviceInfoService {
     private static final String MOTOR_DEVICE_LATEST_KEY = "motor-device-latest";
     private static final Duration DEVICE_INFO_TTL = Duration.ofMinutes(10);
 
+    /**
+     * Redis latest key 삭제 시,
+     * 현재 Redis 값이 expectedDeviceId와 같을 때만 삭제하도록 하는 Lua 스크립트.
+     *
+     * 이유:
+     * get()으로 읽은 뒤 delete()를 별도로 수행하면,
+     * 그 사이에 latest 값이 다른 deviceId로 바뀌었을 때 새 값을 잘못 삭제할 수 있음.
+     * 이를 원자적으로(compare-and-delete) 처리하기 위해 Lua script 사용.
+     */
+    private static final DefaultRedisScript<Long> COMPARE_AND_DELETE_SCRIPT =
+            new DefaultRedisScript<>(
+                    """
+                    if redis.call('get', KEYS[1]) == ARGV[1] then
+                        return redis.call('del', KEYS[1])
+                    else
+                        return 0
+                    end
+                    """,
+                    Long.class
+            );
+
     private final StringRedisTemplate stringRedisTemplate;
 
     public EmgDeviceInfoResponse saveEmgDeviceInfo(EmgDeviceInfoRequest request) {
@@ -33,6 +56,7 @@ public class DeviceInfoService {
         try {
             log.info("[EMG] save start - key={}, status={}", key, request.connectionStatus());
 
+            // deviceId별 상세 상태 정보를 Redis hash에 저장
             stringRedisTemplate.opsForHash().putAll(
                     key,
                     Map.of(
@@ -41,11 +65,13 @@ public class DeviceInfoService {
                     )
             );
 
+            // 상세 상태 정보는 일정 시간 후 자동 만료되도록 TTL 설정
             Boolean expireApplied = stringRedisTemplate.expire(key, DEVICE_INFO_TTL);
             if (Boolean.FALSE.equals(expireApplied)) {
                 log.warn("[EMG] failed to set TTL for device info key - key={}", key);
             }
 
+            // 현재 가장 최근에 연결된 EMG deviceId를 latest key에 저장
             stringRedisTemplate.opsForValue().set(
                     EMG_DEVICE_LATEST_KEY,
                     request.emgDeviceId(),
@@ -72,6 +98,7 @@ public class DeviceInfoService {
         try {
             log.info("[MOTOR] save start - key={}, status={}", key, request.connectionStatus());
 
+            // deviceId별 상세 상태 정보를 Redis hash에 저장
             stringRedisTemplate.opsForHash().putAll(
                     key,
                     Map.of(
@@ -80,11 +107,13 @@ public class DeviceInfoService {
                     )
             );
 
+            // 상세 상태 정보는 일정 시간 후 자동 만료되도록 TTL 설정
             Boolean expireApplied = stringRedisTemplate.expire(key, DEVICE_INFO_TTL);
             if (Boolean.FALSE.equals(expireApplied)) {
                 log.warn("[MOTOR] failed to set TTL for device info key - key={}", key);
             }
 
+            // 현재 가장 최근에 연결된 MOTOR deviceId를 latest key에 저장
             stringRedisTemplate.opsForValue().set(
                     MOTOR_DEVICE_LATEST_KEY,
                     request.motorDeviceId(),
@@ -105,20 +134,52 @@ public class DeviceInfoService {
         }
     }
 
+    /**
+     * 현재 가장 최근 EMG deviceId 조회
+     * - 즉시 삭제하지 않고 조회만 수행
+     * - 실제 삭제는 DB commit 이후 별도 수행
+     */
     public String getLatestEmgDeviceId() {
         return stringRedisTemplate.opsForValue().get(EMG_DEVICE_LATEST_KEY);
     }
 
-    public void deleteLatestEmgDeviceId() {
-        stringRedisTemplate.delete(EMG_DEVICE_LATEST_KEY);
-    }
-
+    /**
+     * 현재 가장 최근 MOTOR deviceId 조회
+     * - 즉시 삭제하지 않고 조회만 수행
+     * - 실제 삭제는 DB commit 이후 별도 수행
+     */
     public String getLatestMotorDeviceId() {
         return stringRedisTemplate.opsForValue().get(MOTOR_DEVICE_LATEST_KEY);
     }
 
-    public void deleteLatestMotorDeviceId() {
-        stringRedisTemplate.delete(MOTOR_DEVICE_LATEST_KEY);
+    /**
+     * Redis latest EMG key의 현재 값이 expectedDeviceId와 같을 때만 삭제
+     *
+     * @return true  -> 삭제 성공
+     *         false -> 값이 다르거나 이미 없어서 삭제하지 않음
+     */
+    public boolean deleteLatestEmgDeviceIdIfMatch(String expectedDeviceId) {
+        Long result = stringRedisTemplate.execute(
+                COMPARE_AND_DELETE_SCRIPT,
+                Collections.singletonList(EMG_DEVICE_LATEST_KEY),
+                expectedDeviceId
+        );
+        return Long.valueOf(1L).equals(result);
+    }
+
+    /**
+     * Redis latest MOTOR key의 현재 값이 expectedDeviceId와 같을 때만 삭제
+     *
+     * @return true  -> 삭제 성공
+     *         false -> 값이 다르거나 이미 없어서 삭제하지 않음
+     */
+    public boolean deleteLatestMotorDeviceIdIfMatch(String expectedDeviceId) {
+        Long result = stringRedisTemplate.execute(
+                COMPARE_AND_DELETE_SCRIPT,
+                Collections.singletonList(MOTOR_DEVICE_LATEST_KEY),
+                expectedDeviceId
+        );
+        return Long.valueOf(1L).equals(result);
     }
 
     private String now() {

--- a/src/main/java/com/neuromove/backend/domain/device/service/DeviceInfoService.java
+++ b/src/main/java/com/neuromove/backend/domain/device/service/DeviceInfoService.java
@@ -105,12 +105,20 @@ public class DeviceInfoService {
         }
     }
 
-    public String consumeLatestEmgDeviceId() {
-        return stringRedisTemplate.opsForValue().getAndDelete(EMG_DEVICE_LATEST_KEY);
+    public String getLatestEmgDeviceId() {
+        return stringRedisTemplate.opsForValue().get(EMG_DEVICE_LATEST_KEY);
     }
 
-    public String consumeLatestMotorDeviceId() {
-        return stringRedisTemplate.opsForValue().getAndDelete(MOTOR_DEVICE_LATEST_KEY);
+    public void deleteLatestEmgDeviceId() {
+        stringRedisTemplate.delete(EMG_DEVICE_LATEST_KEY);
+    }
+
+    public String getLatestMotorDeviceId() {
+        return stringRedisTemplate.opsForValue().get(MOTOR_DEVICE_LATEST_KEY);
+    }
+
+    public void deleteLatestMotorDeviceId() {
+        stringRedisTemplate.delete(MOTOR_DEVICE_LATEST_KEY);
     }
 
     private String now() {

--- a/src/main/java/com/neuromove/backend/domain/device/service/EmgDeviceService.java
+++ b/src/main/java/com/neuromove/backend/domain/device/service/EmgDeviceService.java
@@ -14,6 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 
@@ -28,16 +30,21 @@ public class EmgDeviceService {
 
     @Transactional
     public EmgDeviceRegisterResponse register(User user, EmgDeviceRegisterRequest request) {
+        // Redis에 저장된 현재 latest EMG deviceId를 조회
+        // 이 시점에는 삭제하지 않음
         String emgDeviceId = deviceInfoService.getLatestEmgDeviceId();
 
+        // latest 값이 없으면 아직 연결된 EMG 장치가 없다고 판단
         if (emgDeviceId == null || emgDeviceId.isBlank()) {
             throw new CustomException(ErrorCode.EMG_DEVICE_NOT_CONNECTED);
         }
 
+        // 이미 등록된 deviceId라면 중복 등록 방지
         if (emgDeviceRepository.existsByEmgDeviceId(emgDeviceId)) {
             throw new CustomException(ErrorCode.EMG_DEVICE_ALREADY_REGISTERED);
         }
 
+        // 사용자 입력(name)과 Redis에서 읽은 deviceId를 합쳐 최종 등록 엔티티 생성
         EmgDevice emgDevice = EmgDevice.builder()
                 .emgDeviceId(emgDeviceId)
                 .user(user)
@@ -47,16 +54,44 @@ public class EmgDeviceService {
 
         EmgDevice savedDevice;
         try {
+            // 실제 DB 저장
             savedDevice = emgDeviceRepository.save(emgDevice);
         } catch (DataIntegrityViolationException e) {
+            // 동시성/유니크 제약 등으로 인한 DB 레벨 중복 예외 방어
             throw new CustomException(ErrorCode.EMG_DEVICE_ALREADY_REGISTERED);
         }
 
-        try {
-            deviceInfoService.deleteLatestEmgDeviceId();
-        } catch (Exception e) {
-            log.warn("Failed to delete latest EMG device key", e);
-        }
+        // afterCommit 콜백 내부에서 사용하기 위해 final 변수로 보관
+        final String registeredEmgDeviceId = emgDeviceId;
+
+        // Redis latest key 정리는 save 직후가 아니라 "트랜잭션 commit 성공 후" 수행
+        // 이유:
+        // save()가 끝났더라도 실제 commit은 메서드 종료 후 일어날 수 있으므로,
+        // commit 실패 시 Redis 값이 먼저 사라지는 문제를 막기 위함
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                try {
+                    // 내가 읽은 deviceId와 현재 Redis latest 값이 같을 때만 삭제
+                    // 중간에 더 새로운 값으로 바뀐 경우에는 삭제하지 않음
+                    boolean deleted = deviceInfoService.deleteLatestEmgDeviceIdIfMatch(registeredEmgDeviceId);
+
+                    if (!deleted) {
+                        log.info(
+                                "Skipped deleting latest EMG device key because Redis value changed. expectedDeviceId={}",
+                                registeredEmgDeviceId
+                        );
+                    }
+                } catch (Exception e) {
+                    // Redis 정리 실패가 등록 API 자체를 실패시키지 않도록 로그만 남김
+                    log.warn(
+                            "Failed to delete latest EMG device key after commit. expectedDeviceId={}",
+                            registeredEmgDeviceId,
+                            e
+                    );
+                }
+            }
+        });
 
         return EmgDeviceRegisterResponse.from(savedDevice);
     }

--- a/src/main/java/com/neuromove/backend/domain/device/service/EmgDeviceService.java
+++ b/src/main/java/com/neuromove/backend/domain/device/service/EmgDeviceService.java
@@ -10,12 +10,14 @@ import com.neuromove.backend.domain.user.entity.User;
 import com.neuromove.backend.global.exception.CustomException;
 import com.neuromove.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -26,7 +28,7 @@ public class EmgDeviceService {
 
     @Transactional
     public EmgDeviceRegisterResponse register(User user, EmgDeviceRegisterRequest request) {
-        String emgDeviceId = deviceInfoService.consumeLatestEmgDeviceId();
+        String emgDeviceId = deviceInfoService.getLatestEmgDeviceId();
 
         if (emgDeviceId == null || emgDeviceId.isBlank()) {
             throw new CustomException(ErrorCode.EMG_DEVICE_NOT_CONNECTED);
@@ -43,12 +45,20 @@ public class EmgDeviceService {
                 .isActive(true)
                 .build();
 
+        EmgDevice savedDevice;
         try {
-            EmgDevice savedDevice = emgDeviceRepository.save(emgDevice);
-            return EmgDeviceRegisterResponse.from(savedDevice);
+            savedDevice = emgDeviceRepository.save(emgDevice);
         } catch (DataIntegrityViolationException e) {
             throw new CustomException(ErrorCode.EMG_DEVICE_ALREADY_REGISTERED);
         }
+
+        try {
+            deviceInfoService.deleteLatestEmgDeviceId();
+        } catch (Exception e) {
+            log.warn("Failed to delete latest EMG device key", e);
+        }
+
+        return EmgDeviceRegisterResponse.from(savedDevice);
     }
 
     public EmgDeviceListResponse getMyDevices(User user) {

--- a/src/main/java/com/neuromove/backend/domain/device/service/MotorDeviceService.java
+++ b/src/main/java/com/neuromove/backend/domain/device/service/MotorDeviceService.java
@@ -11,11 +11,13 @@ import com.neuromove.backend.domain.user.entity.User;
 import com.neuromove.backend.global.exception.CustomException;
 import com.neuromove.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 
 @Slf4j
@@ -29,16 +31,21 @@ public class MotorDeviceService {
 
     @Transactional
     public MotorDeviceRegisterResponse register(User user, MotorDeviceRegisterRequest request) {
+        // Redis에 저장된 현재 latest MOTOR deviceId 조회
+        // 조회만 하고 즉시 삭제하지 않음
         String motorDeviceId = deviceInfoService.getLatestMotorDeviceId();
 
+        // latest 값이 없으면 연결된 MOTOR 장치가 없다고 판단
         if (motorDeviceId == null || motorDeviceId.isBlank()) {
             throw new CustomException(ErrorCode.MOTOR_DEVICE_NOT_CONNECTED);
         }
 
+        // 이미 등록된 deviceId라면 중복 등록 방지
         if (motorDeviceRepository.existsByMotorDeviceId(motorDeviceId)) {
             throw new CustomException(ErrorCode.MOTOR_DEVICE_ALREADY_REGISTERED);
         }
 
+        // Redis에서 읽은 deviceId + 사용자 입력(name)으로 최종 등록 엔티티 생성
         MotorDevice motorDevice = MotorDevice.builder()
                 .motorDeviceId(motorDeviceId)
                 .user(user)
@@ -49,16 +56,40 @@ public class MotorDeviceService {
 
         MotorDevice savedDevice;
         try {
+            // 실제 DB 저장
             savedDevice = motorDeviceRepository.save(motorDevice);
         } catch (DataIntegrityViolationException e) {
+            // 유니크 제약 등으로 인한 DB 레벨 중복 예외 방어
             throw new CustomException(ErrorCode.MOTOR_DEVICE_ALREADY_REGISTERED);
         }
 
-        try {
-            deviceInfoService.deleteLatestMotorDeviceId();
-        } catch (Exception e) {
-            log.warn("Failed to delete latest MOTOR device key", e);
-        }
+        final String registeredMotorDeviceId = motorDeviceId;
+
+        // Redis latest key 정리는 트랜잭션 commit 성공 후 수행
+        // commit 전에 삭제하면, 이후 롤백 시 Redis 값까지 사라져 재시도가 불가능해질 수 있음
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                try {
+                    // 내가 읽은 deviceId와 Redis 현재 값이 일치할 때만 삭제
+                    boolean deleted = deviceInfoService.deleteLatestMotorDeviceIdIfMatch(registeredMotorDeviceId);
+
+                    if (!deleted) {
+                        log.info(
+                                "Skipped deleting latest MOTOR device key because Redis value changed. expectedDeviceId={}",
+                                registeredMotorDeviceId
+                        );
+                    }
+                } catch (Exception e) {
+                    // Redis 정리 실패는 등록 성공 자체를 실패로 만들지 않음
+                    log.warn(
+                            "Failed to delete latest MOTOR device key after commit. expectedDeviceId={}",
+                            registeredMotorDeviceId,
+                            e
+                    );
+                }
+            }
+        });
 
         return MotorDeviceRegisterResponse.from(savedDevice);
     }

--- a/src/main/java/com/neuromove/backend/domain/device/service/MotorDeviceService.java
+++ b/src/main/java/com/neuromove/backend/domain/device/service/MotorDeviceService.java
@@ -15,8 +15,10 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -27,7 +29,7 @@ public class MotorDeviceService {
 
     @Transactional
     public MotorDeviceRegisterResponse register(User user, MotorDeviceRegisterRequest request) {
-        String motorDeviceId = deviceInfoService.consumeLatestMotorDeviceId();
+        String motorDeviceId = deviceInfoService.getLatestMotorDeviceId();
 
         if (motorDeviceId == null || motorDeviceId.isBlank()) {
             throw new CustomException(ErrorCode.MOTOR_DEVICE_NOT_CONNECTED);
@@ -45,12 +47,20 @@ public class MotorDeviceService {
                 .connectionStatus(ConnectionStatus.CONNECTED)
                 .build();
 
+        MotorDevice savedDevice;
         try {
-            MotorDevice savedDevice = motorDeviceRepository.save(motorDevice);
-            return MotorDeviceRegisterResponse.from(savedDevice);
+            savedDevice = motorDeviceRepository.save(motorDevice);
         } catch (DataIntegrityViolationException e) {
             throw new CustomException(ErrorCode.MOTOR_DEVICE_ALREADY_REGISTERED);
         }
+
+        try {
+            deviceInfoService.deleteLatestMotorDeviceId();
+        } catch (Exception e) {
+            log.warn("Failed to delete latest MOTOR device key", e);
+        }
+
+        return MotorDeviceRegisterResponse.from(savedDevice);
     }
 
     public MotorDeviceListResponse getMyDevices(User user) {


### PR DESCRIPTION
## 🔍 관련 이슈
- close #39

<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 프로젝트 구조 변경
- [x] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
- Redis latest deviceId 조회/삭제 로직 분리
- 기존 `getAndDelete()` 방식 제거
- 디바이스 등록 시 DB 저장 성공 후 Redis latest key 삭제하도록 수정
- Redis 삭제 실패 시 서비스에 영향이 없도록 예외 처리 추가 (로그만 출력)
<br>

## 🔧 변경 상세
### 1. DeviceInfoService
- `consumeLatest...()` 제거
- `getLatest...()` / `deleteLatest...()` 메서드로 분리

### 2. EmgDeviceService / MotorDeviceService
- latest deviceId 조회 시 삭제하지 않도록 변경
- DB 저장 성공 이후에만 Redis latest key 삭제
- Redis 삭제 실패 시 warn 로그 처리

<br>

## 🎯 변경 이유
기존에는 Redis latest deviceId를 `getAndDelete()`로 즉시 소비하여
디바이스 등록 중 DB 저장 실패 시 Redis 값이 사라져 재시도가 불가능한 문제가 있다고 판단했습니다.

이를 조회와 삭제 로직으로 분리하고,  
디바이스가 DB에 정상 등록된 이후에만 Redis latest key를 삭제하도록 변경하여  
등록 실패 시에도 재시도가 가능하도록 개선했습니다.

<br>

## 💡 기대 효과
- 디바이스 등록 실패 시 재시도 가능 (UX 개선)
- Redis를 임시 상태 저장소로 활용하고, DB를 최종 데이터로 명확히 분리
- Redis 장애가 서비스 장애로 이어지지 않도록 안정성 확보

<br>


## 👥 전달사항
- 현재는 단일 장치가 켜진다는 가정을 기반으로 latest 구조를 유지

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Separated retrieval and cleanup of “latest device” markers and deferred cleanup until after successful DB commit to improve reliability.
  * Cleanup now only removes markers if they still match the registered device, reducing accidental deletions.
* **Bug Fixes**
  * Ensured cleanup failures no longer affect registration responses and added logging for better observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->