### PR TITLE
[feat] sequenceNumber 중복/역전 검증 로직 제거

### DIFF
--- a/src/main/java/com/neuromove/backend/domain/intent/dto/request/IntentReceiveRequest.java
+++ b/src/main/java/com/neuromove/backend/domain/intent/dto/request/IntentReceiveRequest.java
@@ -13,9 +13,6 @@ public class IntentReceiveRequest {
     @NotBlank
     private String sessionId;
 
-    @NotNull
-    private Long sequenceNumber;
-
     @NotBlank
     private String emgDeviceId;
 

--- a/src/main/java/com/neuromove/backend/domain/intent/service/IntentService.java
+++ b/src/main/java/com/neuromove/backend/domain/intent/service/IntentService.java
@@ -58,14 +58,7 @@ public class IntentService {
         Session session = sessionRepository.findById(request.getSessionId())
                 .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
 
-        // [Fail-safe 1] sequenceNumber 중복/지연 방지
-        if (session.getLastSequenceNumber() != null
-                && request.getSequenceNumber() <= session.getLastSequenceNumber()) {
-            throw new CustomException(ErrorCode.DUPLICATE_SEQUENCE);
-        }
-        session.updateLastSequenceNumber(request.getSequenceNumber());
-
-        // [Fail-safe 2] 명령 유효시간 처리 (3초 초과 시 BLOCKED)
+        // [Fail-safe 1] 명령 유효시간 처리 (3초 초과 시 BLOCKED)
         long now = Instant.now().toEpochMilli();
         boolean stale = (now - request.getTimestamp()) > STALE_COMMAND_MS;
 

--- a/src/main/java/com/neuromove/backend/domain/session/entity/Session.java
+++ b/src/main/java/com/neuromove/backend/domain/session/entity/Session.java
@@ -46,9 +46,6 @@ public class Session {
     @Column(name = "max_risk_score")
     private Float maxRiskScore;
 
-    @Column(name = "last_sequence_number")
-    private Long lastSequenceNumber;
-
     @Column(name = "started_at", nullable = false, updatable = false)
     private LocalDateTime startedAt;
 
@@ -57,10 +54,6 @@ public class Session {
 
     @Column(name = "duration_seconds")
     private Integer durationSeconds;
-
-    public void updateLastSequenceNumber(Long sequenceNumber) {
-        this.lastSequenceNumber = sequenceNumber;
-    }
 
     public void updateMaxRiskScore(float riskScore) {
         if (this.maxRiskScore == null || riskScore > this.maxRiskScore) {

--- a/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/neuromove/backend/global/exception/ErrorCode.java
@@ -28,7 +28,6 @@ public enum ErrorCode {
     MOTOR_DEVICE_ALREADY_REGISTERED(HttpStatus.CONFLICT, "MOTOR_DEVICE_ALREADY_REGISTERED", "이미 등록된 MOTOR 디바이스입니다."),
 
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", "세션을 찾을 수 없습니다."),
-    DUPLICATE_SEQUENCE(HttpStatus.BAD_REQUEST, "DUPLICATE_SEQUENCE", "중복되거나 오래된 sequenceNumber입니다."),
     INVALID_INTERNAL_KEY(HttpStatus.UNAUTHORIZED, "INVALID_INTERNAL_KEY", "유효하지 않은 Internal Key입니다.");
 
     private final HttpStatus status;


### PR DESCRIPTION
## 🔍 관련 이슈
- close #46 

<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
 AI 파트에서 한 번에 다수의 신호를 전송하는 특성상,                                                                                                           
  sequenceNumber 중복/역전 검증이 정상 신호를 과도하게 차단하는 문제가 생길 가능성이 있어서 해당 로직을 제거했습니다.
                                                                                                                                                               
  ## 제거된 내용                                            
                                                                                                                                                               
  - `IntentReceiveRequest` - `sequenceNumber` 필드 제거                                                                                                        
  - `Session` - `lastSequenceNumber` 필드 및 `updateLastSequenceNumber()` 제거
  - `IntentService` - Fail-safe 1 (DUPLICATE_SEQUENCE 체크) 제거                                                                                               
  - `ErrorCode` - `DUPLICATE_SEQUENCE` 에러코드 제거                                                                                                           
                                                                                                                                                               
  ## 이유                                                                                                                                                      
                                                                                                                                                               
  AI 측에서 짧은 시간에 다수의 신호를 연속 전송하기 때문에                                                                                                     
  sequenceNumber 역전이 빈번하게 발생할 수 있고,
  이를 서버에서 검증하면 AI 파트 코드가 불필요하게 복잡해지는 문제가 있었습니다.                                                                               
  나머지 Fail-safe 로직(stale 타임아웃, 이상 패턴 감지)으로 충분히 커버 가능합니다. 

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
