### PR TITLE
[feat] 모터 보드용 raw websocket 추가

### DIFF
--- a/src/main/java/com/neuromove/backend/domain/websocket/interceptor/MotorWebSocketHandshakeInterceptor.java
+++ b/src/main/java/com/neuromove/backend/domain/websocket/interceptor/MotorWebSocketHandshakeInterceptor.java
@@ -1,0 +1,68 @@
+package com.neuromove.backend.domain.websocket.interceptor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+/**
+ * [WebSocket 핸드셰이크 인증 인터셉터]
+ *
+ * ESP32가 ws://host/ws/motor 연결 시 HTTP Upgrade 요청에
+ * X-API-KEY 헤더가 있는지 검증.
+ * 키가 없거나 틀리면 핸드셰이크를 거부(401)해서 연결 자체를 차단.
+ */
+@Slf4j
+@Component
+public class MotorWebSocketHandshakeInterceptor implements HandshakeInterceptor {
+
+    private static final String API_KEY_HEADER = "X-API-KEY";
+
+    @Value("${security.api-key}")
+    private String internalApiKey;
+
+    /**
+     * 핸드셰이크 전 호출 - false 반환 시 연결 거부
+     */
+    @Override
+    public boolean beforeHandshake(
+            ServerHttpRequest request,
+            ServerHttpResponse response,
+            WebSocketHandler wsHandler,
+            Map<String, Object> attributes
+    ) {
+        String key = request.getHeaders().getFirst(API_KEY_HEADER);
+
+        if (key == null || key.isBlank() || !internalApiKey.equals(key)) {
+            log.warn("[WS] 핸드셰이크 거부 - 유효하지 않은 X-API-KEY. remoteAddress={}",
+                    request.getRemoteAddress());
+
+            // HTTP 401 반환
+            if (response instanceof ServletServerHttpResponse servletResponse) {
+                servletResponse.getServletResponse()
+                        .setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            }
+            return false;
+        }
+
+        log.info("[WS] 핸드셰이크 인증 성공. remoteAddress={}", request.getRemoteAddress());
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(
+            ServerHttpRequest request,
+            ServerHttpResponse response,
+            WebSocketHandler wsHandler,
+            Exception exception
+    ) {
+        // 핸드셰이크 후 처리 불필요
+    }
+}

--- a/src/main/java/com/neuromove/backend/global/config/RawWebSocketConfig.java
+++ b/src/main/java/com/neuromove/backend/global/config/RawWebSocketConfig.java
@@ -15,14 +15,13 @@ public class RawWebSocketConfig implements WebSocketConfigurer {
 
     private final MotorWebSocketHandler motorWebSocketHandler;
 
-    @Value("${app.websocket.allowed-origins:*}")
-    private String[] allowedOrigins;
     /**
      * Raw WebSocket (모터 보드용)
+     * ESP32 같은 임베디드 디바이스는 Origin 헤더를 보내지 않으므로 * 고정
      */
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry.addHandler(motorWebSocketHandler, "/ws/motor")
-                .setAllowedOriginPatterns(allowedOrigins);
+                .setAllowedOriginPatterns("*");
     }
 }

--- a/src/main/java/com/neuromove/backend/global/config/RawWebSocketConfig.java
+++ b/src/main/java/com/neuromove/backend/global/config/RawWebSocketConfig.java
@@ -1,8 +1,8 @@
 package com.neuromove.backend.global.config;
 
 import com.neuromove.backend.domain.websocket.handler.MotorWebSocketHandler;
+import com.neuromove.backend.domain.websocket.interceptor.MotorWebSocketHandshakeInterceptor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
@@ -14,14 +14,17 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 public class RawWebSocketConfig implements WebSocketConfigurer {
 
     private final MotorWebSocketHandler motorWebSocketHandler;
+    private final MotorWebSocketHandshakeInterceptor handshakeInterceptor;
 
     /**
      * Raw WebSocket (모터 보드용)
-     * ESP32 같은 임베디드 디바이스는 Origin 헤더를 보내지 않으므로 * 고정
+     * - Origin: ESP32는 Origin 헤더 없이 연결하므로 * 허용
+     * - 인증: HandshakeInterceptor에서 X-API-KEY 헤더 검증
      */
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry.addHandler(motorWebSocketHandler, "/ws/motor")
+                .addInterceptors(handshakeInterceptor)
                 .setAllowedOriginPatterns("*");
     }
 }


### PR DESCRIPTION
모터 WebSocket은 브라우저가 아닌 ESP32 디바이스 전용, 환경변수와 무관하게 setAllowedOriginPatterns("*")로 고정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced motor WebSocket endpoint reliability by simplifying cross-origin request handling to accept connections from any source. This resolves connectivity challenges that previously limited motor control access based on client origin, ensuring consistent functionality across all client environments and network configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Capstone-EMG-3P1L/NeuroMove_backend/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->